### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,7 @@ jobs:
         pip install build
     
     - name: Build package
-      run: |
-        # Ensure we have the latest tag
-        git fetch --tags
-        python -m build
+      run: python -m build
     
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Summary
- Remove redundant `git fetch --tags` from release workflow that was causing tag conflicts

## Problem
The release workflow was failing with:
```
! [rejected]        v0.2.0     -> v0.2.0  (would clobber existing tag)
```

## Solution
The `actions/checkout@v3` with `fetch-depth: 0` already fetches all tags, so the additional `git fetch --tags` was redundant and causing conflicts.

## Test Plan
- [x] CI passes
- [ ] Release workflow will succeed on next tag push after merge