### PR TITLE
Fix license declaration to Apache-2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,4 +170,4 @@ src/witticism/
 
 ## License
 
-MIT
+Apache-2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.9,<3.13"
 authors = [
     {name = "Aaron Stannard", email = "aaron@petabridge.com"}
 ]
-license = "MIT"
+license = "Apache-2.0"
 keywords = ["transcription", "whisperx", "speech-recognition", "push-to-talk"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary
- Fix license declaration in pyproject.toml and README to correctly state Apache-2.0

## Problem
The repository contains an Apache-2.0 LICENSE file, but the package metadata and README incorrectly declared the license as MIT.

## Changes
- Update pyproject.toml license field from "MIT" to "Apache-2.0"
- Update README.md license section from "MIT" to "Apache-2.0"

## Note
The LICENSE file itself is already correct (Apache-2.0), this just fixes the metadata to match.