### PR TITLE
Fix branch references from main to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Built to solve GPU acceleration issues with whisper.cpp. WhisperX provides:
 One-command installation with automatic GPU detection and auto-start:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/Aaronontheweb/witticism/main/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/witticism/master/install.sh | bash
 ```
 
 This will:
@@ -75,7 +75,7 @@ pipx upgrade witticism
 
 Or use the upgrade script:
 ```bash
-curl -sSL https://raw.githubusercontent.com/Aaronontheweb/witticism/main/upgrade.sh | bash
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/witticism/master/upgrade.sh | bash
 ```
 
 ## Usage

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -12,7 +12,7 @@ if command -v witticism &> /dev/null; then
     echo "Current version: $CURRENT_VERSION"
 else
     echo "Witticism not installed. Running installer..."
-    curl -sSL https://raw.githubusercontent.com/Aaronontheweb/witticism/main/install.sh | bash
+    curl -sSL https://raw.githubusercontent.com/Aaronontheweb/witticism/master/install.sh | bash
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
- Fix installation URLs to use correct branch name `master` instead of `main`

## Problem
The install commands were returning 404 errors because they referenced `main` branch, but the repository uses `master` as the default branch.

## Changes
- Update README.md installation URLs from `/main/` to `/master/`
- Update upgrade.sh fallback URL from `/main/` to `/master/`

## Test
```bash
curl -sSL https://raw.githubusercontent.com/Aaronontheweb/witticism/master/install.sh | bash
```
This should now work correctly.