### PR TITLE
Make install scripts verbose to show progress

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,10 +8,13 @@ echo "🎙️ Installing Witticism..."
 
 # 1. Install pipx if not present
 if ! command -v pipx &> /dev/null; then
-    echo "Installing pipx..."
+    echo "📦 Installing pipx package manager..."
     python3 -m pip install --user pipx
     python3 -m pipx ensurepath
     export PATH="$HOME/.local/bin:$PATH"
+    echo "✓ pipx installed"
+else
+    echo "✓ pipx already installed"
 fi
 
 # 2. Detect GPU and install with right CUDA
@@ -32,9 +35,12 @@ else
 fi
 
 # 3. Install Witticism
-echo "Installing Witticism..."
-pipx install witticism --pip-args="--index-url $INDEX_URL" \
-    --pip-args="--extra-index-url https://pypi.org/simple"
+echo "📦 Installing Witticism with dependencies..."
+echo "⏳ This may take several minutes as PyTorch and WhisperX are large packages"
+echo ""
+pipx install witticism --verbose --pip-args="--index-url $INDEX_URL" \
+    --pip-args="--extra-index-url https://pypi.org/simple" \
+    --pip-args="--verbose"
 
 # 4. Set up auto-start
 echo "Setting up auto-start..."

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -65,8 +65,12 @@ else
 fi
 
 # Upgrade with pipx
-pipx upgrade witticism --pip-args="--index-url $INDEX_URL" \
-    --pip-args="--extra-index-url https://pypi.org/simple"
+echo "📦 Downloading and installing updates..."
+echo "⏳ This may take several minutes for large dependencies"
+echo ""
+pipx upgrade witticism --verbose --pip-args="--index-url $INDEX_URL" \
+    --pip-args="--extra-index-url https://pypi.org/simple" \
+    --pip-args="--verbose"
 
 # Restore settings
 if [ -f "$HOME/.config/witticism/config.yaml.backup" ]; then


### PR DESCRIPTION
## Summary
- Add verbose output to install.sh and upgrade.sh to show installation progress

## Problem
Users were experiencing long waits during installation with no feedback, making them think the script had hung. PyTorch and WhisperX are large packages (several GB) and the download can take several minutes.

## Solution
- Add `--verbose` flags to pipx commands
- Add `--verbose` to pip args to show download progress
- Add clear status messages explaining what's happening
- Warn users upfront that downloads may take time

## Changes
- ✅ install.sh: Added verbose flags and progress messages
- ✅ upgrade.sh: Added verbose flags and progress messages

## Test
Run the install script and verify you see:
1. Status messages about what's being installed
2. pip download progress bars
3. Clear indication that large packages are being downloaded

This provides much better user experience during the lengthy installation process.