### PR TITLE
Fix PyTorch CUDA compatibility for GTX 1080 and older GPUs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,9 +38,7 @@ fi
 echo "📦 Installing Witticism with dependencies..."
 echo "⏳ This may take several minutes as PyTorch and WhisperX are large packages"
 echo ""
-pipx install witticism --verbose --pip-args="--index-url $INDEX_URL" \
-    --pip-args="--extra-index-url https://pypi.org/simple" \
-    --pip-args="--verbose"
+pipx install witticism --verbose --pip-args="--index-url $INDEX_URL --extra-index-url https://pypi.org/simple --verbose"
 
 # 4. Set up auto-start
 echo "Setting up auto-start..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 ]
 dependencies = [
     "whisperx>=3.1.0",
-    "torch>=2.0.0",
-    "torchaudio>=2.0.0",
+    "torch>=2.0.0,<2.4.0",  # Cap at 2.4 for GTX 10xx GPU compatibility
+    "torchaudio>=2.0.0,<2.4.0",
     "PyQt5>=5.15.0",
     "pyaudio>=0.2.11",
     "pynput>=1.7.0",

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -68,9 +68,7 @@ fi
 echo "📦 Downloading and installing updates..."
 echo "⏳ This may take several minutes for large dependencies"
 echo ""
-pipx upgrade witticism --verbose --pip-args="--index-url $INDEX_URL" \
-    --pip-args="--extra-index-url https://pypi.org/simple" \
-    --pip-args="--verbose"
+pipx upgrade witticism --verbose --pip-args="--index-url $INDEX_URL --extra-index-url https://pypi.org/simple --verbose"
 
 # Restore settings
 if [ -f "$HOME/.config/witticism/config.yaml.backup" ]; then


### PR DESCRIPTION
## Summary
- Fix PyTorch installation for GTX 1080 and other older GPUs (compute capability < 7.0)
- Fix pipx pip-args handling to properly use custom PyTorch index URLs

## Problem
1. PyTorch 2.4+ dropped support for compute capability < 7.0 (GTX 10xx series and older)
2. The install script was passing multiple `--pip-args` flags to pipx, but pipx only uses the last one
3. This caused pipx to ignore the CUDA-specific index URL and install PyTorch 2.8 with CUDA 12.8, which doesn't support GTX 1080

## Solution
1. Cap PyTorch and torchaudio at <2.4.0 for compatibility with older GPUs
2. Fix install.sh and upgrade.sh to pass pip args as a single string
3. This ensures the correct CUDA version gets installed

## Error that was happening:
```
NVIDIA GeForce GTX 1080 with CUDA capability sm_61 is not compatible with the current PyTorch installation.
The current PyTorch install supports CUDA capabilities sm_70 sm_75 sm_80 sm_86 sm_90 sm_100 sm_120.
```

## Test
After this fix:
- GTX 1080 will get PyTorch 2.3.x with CUDA 11.8 support
- Newer GPUs will still get appropriate versions
- The install script properly uses the PyTorch index URL