### PR TITLE
Update upgrade documentation to clarify service restart behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,12 @@ To upgrade to the latest version:
 pipx upgrade witticism
 ```
 
-Or use the upgrade script:
+Or use the upgrade script (recommended):
 ```bash
 curl -sSL https://raw.githubusercontent.com/Aaronontheweb/witticism/master/upgrade.sh | bash
 ```
+
+**Note**: The upgrade script will automatically stop any running Witticism instance during the upgrade and restart it afterward if auto-start is configured.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Added note that upgrade script automatically stops running instance during upgrades
- Clarifies that service restarts after upgrade if auto-start is configured
- Helps users understand expected brief interruption during upgrades

## Test plan
- [x] Verify documentation changes are clear and accurate
- [x] Confirm upgrade script behavior matches documentation