### PR TITLE
Fix upgrade script to force package updates

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -68,7 +68,7 @@ fi
 echo "📦 Downloading and installing updates..."
 echo "⏳ This may take several minutes for large dependencies"
 echo ""
-pipx upgrade witticism --verbose --pip-args="--index-url $INDEX_URL --extra-index-url https://pypi.org/simple --verbose"
+pipx upgrade witticism --force --verbose --pip-args="--index-url $INDEX_URL --extra-index-url https://pypi.org/simple --verbose"
 
 # Restore settings
 if [ -f "$HOME/.config/witticism/config.yaml.backup" ]; then


### PR DESCRIPTION
## Summary
- Add `--force` flag to pipx upgrade command in upgrade.sh
- Ensures updates are pulled from PyPI even when same version is detected locally
- Resolves issue where upgrade script incorrectly reported being up-to-date

## Test plan
- [x] Tested upgrade script with --force flag
- [x] Verified script now properly forces upgrades from PyPI
- [x] Confirmed script works when upgrading from 0.2.1 to 0.2.2