### PR TITLE
Fix installer to automatically install PortAudio dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,30 @@ set -e
 
 echo "🎙️ Installing Witticism..."
 
+# Install system dependencies for pyaudio
+if command -v apt-get &> /dev/null; then
+    # Debian/Ubuntu
+    echo "📦 Installing system dependencies..."
+    if ! dpkg -l | grep -q portaudio19-dev; then
+        echo "Installing PortAudio development headers (required for voice input)..."
+        sudo apt-get update && sudo apt-get install -y portaudio19-dev
+    fi
+elif command -v dnf &> /dev/null; then
+    # Fedora/RHEL
+    echo "📦 Installing system dependencies..."
+    if ! rpm -qa | grep -q portaudio-devel; then
+        echo "Installing PortAudio development headers (required for voice input)..."
+        sudo dnf install -y portaudio-devel
+    fi
+elif command -v pacman &> /dev/null; then
+    # Arch Linux
+    echo "📦 Installing system dependencies..."
+    if ! pacman -Q portaudio &> /dev/null; then
+        echo "Installing PortAudio (required for voice input)..."
+        sudo pacman -S --noconfirm portaudio
+    fi
+fi
+
 # 1. Install pipx if not present
 if ! command -v pipx &> /dev/null; then
     echo "📦 Installing pipx package manager..."


### PR DESCRIPTION
## Summary
- Adds automatic installation of PortAudio development headers to prevent pyaudio compilation errors
- Detects Linux distribution and installs the appropriate package

## Problem
Users were encountering the error `portaudio.h: No such file or directory` when trying to install Witticism because pyaudio requires PortAudio development headers to compile.

## Solution
The installer script now:
1. Detects the Linux distribution (Debian/Ubuntu, Fedora/RHEL, or Arch)
2. Checks if PortAudio is already installed
3. If not installed, uses sudo to install the appropriate package:
   - `portaudio19-dev` for Debian/Ubuntu
   - `portaudio-devel` for Fedora/RHEL
   - `portaudio` for Arch Linux

## Test Plan
- [ ] Install succeeds on Ubuntu without manually installing portaudio19-dev
- [ ] Install succeeds on Fedora without manually installing portaudio-devel
- [ ] Install succeeds on Arch without manually installing portaudio
- [ ] Script correctly skips installation if package is already present