### PR TITLE
Add --version flag to CLI

### DIFF
--- a/src/witticism/main.py
+++ b/src/witticism/main.py
@@ -24,6 +24,7 @@ from witticism.ui.system_tray import SystemTrayApp
 from witticism.utils.output_manager import OutputManager
 from witticism.utils.config_manager import ConfigManager
 from witticism.utils.logging_config import setup_logging
+import witticism
 
 logger = logging.getLogger(__name__)
 
@@ -202,6 +203,11 @@ def main():
         "--reset-config",
         action="store_true",
         help="Reset configuration to defaults"
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {witticism.__version__}"
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- Adds a `--version` argument to the main CLI parser
- Displays version information and exits when used
- Uses argparse's built-in action="version" functionality

## Test plan
- Test that `python -m witticism --version` displays correct version information
- Verify the flag appears in help output with `python -m witticism --help`