### PR TITLE
Fix dialog window sizes and add desktop integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,9 @@ src/witticism/_version.py
 
 # Claude worktree management
 .claude-wt/worktrees
+
+# Local testing files
+test_local.sh
+test_dialogs.py
+cleanup_local.sh
+.test_venv/

--- a/README.md
+++ b/README.md
@@ -85,6 +85,25 @@ X-GNOME-Autostart-enabled=true
 EOF
 ```
 
+### Desktop Integration (Optional)
+
+To add Witticism to your application launcher:
+
+```bash
+# After installing with pipx, run:
+./scripts/install_desktop_entry.sh
+```
+
+This will:
+- Add Witticism to your application menu/launcher
+- Install application icons
+- Enable launching from your desktop environment
+
+To remove the desktop integration:
+```bash
+./scripts/uninstall_desktop_entry.sh
+```
+
 ### Upgrading
 
 To upgrade to the latest version:

--- a/assets/witticism.desktop
+++ b/assets/witticism.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Witticism
+Comment=WhisperX-powered voice transcription tool
+Exec=witticism
+Icon=witticism
+Terminal=false
+Categories=Utility;AudioVideo;Accessibility;
+Keywords=voice;transcription;speech;whisper;dictation;
+StartupNotify=false

--- a/scripts/generate_icon.py
+++ b/scripts/generate_icon.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Generate Witticism icon as PNG file."""
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from PyQt5.QtWidgets import QApplication
+from witticism.ui.icon_utils import create_witticism_icon
+
+def main():
+    app = QApplication(sys.argv)
+    
+    # Generate icons at different sizes
+    sizes = [16, 24, 32, 48, 64, 128, 256, 512]
+    
+    assets_dir = Path(__file__).parent.parent / "assets"
+    assets_dir.mkdir(exist_ok=True)
+    
+    for size in sizes:
+        icon = create_witticism_icon(size)
+        pixmap = icon.pixmap(size, size)
+        
+        # Save as PNG
+        filename = assets_dir / f"witticism_{size}x{size}.png"
+        pixmap.save(str(filename), "PNG")
+        print(f"Generated {filename}")
+    
+    # Also generate a main icon at 512x512
+    main_icon = create_witticism_icon(512)
+    main_pixmap = main_icon.pixmap(512, 512)
+    main_filename = assets_dir / "witticism.png"
+    main_pixmap.save(str(main_filename), "PNG")
+    print(f"Generated {main_filename}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install_desktop_entry.sh
+++ b/scripts/install_desktop_entry.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Install desktop entry and icon for Witticism
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Installing Witticism desktop entry...${NC}"
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Ensure we're in the project directory
+cd "$PROJECT_DIR"
+
+# Generate icons if they don't exist
+if [ ! -f "assets/witticism.png" ]; then
+    echo -e "${YELLOW}Generating icons...${NC}"
+    python3 scripts/generate_icon.py || {
+        echo -e "${RED}Failed to generate icons. Make sure PyQt5 is installed.${NC}"
+        exit 1
+    }
+fi
+
+# Install icons
+echo -e "${GREEN}Installing icons...${NC}"
+for size in 16 24 32 48 64 128 256 512; do
+    icon_dir="$HOME/.local/share/icons/hicolor/${size}x${size}/apps"
+    mkdir -p "$icon_dir"
+    if [ -f "assets/witticism_${size}x${size}.png" ]; then
+        cp "assets/witticism_${size}x${size}.png" "$icon_dir/witticism.png"
+        echo "  Installed ${size}x${size} icon"
+    fi
+done
+
+# Install main icon for legacy applications
+if [ -f "assets/witticism.png" ]; then
+    mkdir -p "$HOME/.local/share/pixmaps"
+    cp "assets/witticism.png" "$HOME/.local/share/pixmaps/witticism.png"
+    echo "  Installed pixmaps icon"
+fi
+
+# Install desktop entry
+echo -e "${GREEN}Installing desktop entry...${NC}"
+desktop_dir="$HOME/.local/share/applications"
+mkdir -p "$desktop_dir"
+
+# Check if witticism is in PATH
+if command -v witticism &> /dev/null; then
+    WITTICISM_EXEC="witticism"
+    echo "  Found witticism in PATH"
+elif [ -f "$HOME/.local/bin/witticism" ]; then
+    WITTICISM_EXEC="$HOME/.local/bin/witticism"
+    echo "  Found witticism in ~/.local/bin"
+else
+    # Try to find pipx installation
+    PIPX_BIN="$HOME/.local/pipx/venvs/witticism/bin/witticism"
+    if [ -f "$PIPX_BIN" ]; then
+        WITTICISM_EXEC="$PIPX_BIN"
+        echo "  Found witticism in pipx"
+    else
+        echo -e "${YELLOW}Warning: Could not find witticism executable.${NC}"
+        echo -e "${YELLOW}Using 'witticism' as exec path - make sure it's in your PATH.${NC}"
+        WITTICISM_EXEC="witticism"
+    fi
+fi
+
+# Create desktop entry with correct exec path
+cat > "$desktop_dir/witticism.desktop" << EOF
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Witticism
+Comment=WhisperX-powered voice transcription tool
+Exec=${WITTICISM_EXEC}
+Icon=witticism
+Terminal=false
+Categories=Utility;AudioVideo;Accessibility;
+Keywords=voice;transcription;speech;whisper;dictation;
+StartupNotify=false
+EOF
+
+# Update desktop database
+if command -v update-desktop-database &> /dev/null; then
+    update-desktop-database "$desktop_dir" 2>/dev/null || true
+fi
+
+# Update icon cache
+if command -v gtk-update-icon-cache &> /dev/null; then
+    gtk-update-icon-cache "$HOME/.local/share/icons/hicolor" 2>/dev/null || true
+fi
+
+echo -e "${GREEN}Installation complete!${NC}"
+echo -e "${GREEN}Witticism should now appear in your application launcher.${NC}"
+echo ""
+echo "If it doesn't appear immediately, you may need to:"
+echo "  1. Log out and log back in"
+echo "  2. Or restart your desktop environment"
+echo "  3. Or run: killall gnome-shell (for GNOME)"

--- a/scripts/uninstall_desktop_entry.sh
+++ b/scripts/uninstall_desktop_entry.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Uninstall desktop entry and icon for Witticism
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Uninstalling Witticism desktop entry...${NC}"
+
+# Remove desktop entry
+desktop_file="$HOME/.local/share/applications/witticism.desktop"
+if [ -f "$desktop_file" ]; then
+    rm "$desktop_file"
+    echo "  Removed desktop entry"
+fi
+
+# Remove icons
+echo -e "${GREEN}Removing icons...${NC}"
+for size in 16 24 32 48 64 128 256 512; do
+    icon_file="$HOME/.local/share/icons/hicolor/${size}x${size}/apps/witticism.png"
+    if [ -f "$icon_file" ]; then
+        rm "$icon_file"
+        echo "  Removed ${size}x${size} icon"
+    fi
+done
+
+# Remove pixmaps icon
+pixmap_file="$HOME/.local/share/pixmaps/witticism.png"
+if [ -f "$pixmap_file" ]; then
+    rm "$pixmap_file"
+    echo "  Removed pixmaps icon"
+fi
+
+# Update desktop database
+if command -v update-desktop-database &> /dev/null; then
+    update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
+fi
+
+# Update icon cache
+if command -v gtk-update-icon-cache &> /dev/null; then
+    gtk-update-icon-cache "$HOME/.local/share/icons/hicolor" 2>/dev/null || true
+fi
+
+echo -e "${GREEN}Uninstallation complete!${NC}"

--- a/src/witticism/ui/about_dialog.py
+++ b/src/witticism/ui/about_dialog.py
@@ -5,12 +5,14 @@ from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel,
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QPixmap, QFont
 import importlib.metadata
+from witticism.ui.icon_utils import create_witticism_icon
 
 class AboutDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("About Witticism")
-        self.setFixedSize(500, 400)
+        self.setWindowIcon(create_witticism_icon())
+        self.setFixedSize(700, 550)
         self.init_ui()
 
     def init_ui(self):
@@ -19,22 +21,10 @@ class AboutDialog(QDialog):
         # Header with icon and title
         header_layout = QHBoxLayout()
 
-        # App icon (create a simple one)
+        # App icon
         icon_label = QLabel()
-        pixmap = QPixmap(64, 64)
-        pixmap.fill(Qt.transparent)
-        from PyQt5.QtGui import QPainter, QColor
-        painter = QPainter(pixmap)
-        painter.setRenderHint(QPainter.Antialiasing)
-        painter.setBrush(QColor(76, 175, 80))
-        painter.setPen(Qt.NoPen)
-        painter.drawEllipse(8, 8, 48, 48)
-        painter.setPen(Qt.white)
-        font = QFont("Arial", 20, QFont.Bold)
-        painter.setFont(font)
-        painter.drawText(pixmap.rect(), Qt.AlignCenter, "W")
-        painter.end()
-        icon_label.setPixmap(pixmap)
+        icon = create_witticism_icon(64)
+        icon_label.setPixmap(icon.pixmap(64, 64))
 
         # Title and version
         title_layout = QVBoxLayout()

--- a/src/witticism/ui/about_dialog.py
+++ b/src/witticism/ui/about_dialog.py
@@ -12,7 +12,8 @@ class AboutDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("About Witticism")
         self.setWindowIcon(create_witticism_icon())
-        self.setFixedSize(700, 550)
+        self.resize(750, 600)
+        self.setMinimumSize(600, 450)
         self.init_ui()
 
     def init_ui(self):

--- a/src/witticism/ui/icon_utils.py
+++ b/src/witticism/ui/icon_utils.py
@@ -4,20 +4,20 @@ from PyQt5.QtCore import Qt
 
 def create_witticism_icon(size: int = 64, color: str = "green") -> QIcon:
     """Create the Witticism icon programmatically.
-    
+
     Args:
         size: Icon size in pixels
         color: Icon color ("green", "red", "yellow", "gray", "orange")
-    
+
     Returns:
         QIcon: The generated icon
     """
     pixmap = QPixmap(size, size)
     pixmap.fill(Qt.transparent)
-    
+
     painter = QPainter(pixmap)
     painter.setRenderHint(QPainter.Antialiasing)
-    
+
     # Map color names to QColor
     color_map = {
         "green": QColor(76, 175, 80),
@@ -26,23 +26,23 @@ def create_witticism_icon(size: int = 64, color: str = "green") -> QIcon:
         "gray": QColor(158, 158, 158),
         "orange": QColor(255, 152, 0)
     }
-    
+
     # Calculate circle dimensions based on size
     margin = size // 8
     circle_size = size - (2 * margin)
-    
+
     # Background circle
     painter.setBrush(color_map.get(color, QColor(76, 175, 80)))
     painter.setPen(Qt.NoPen)
     painter.drawEllipse(margin, margin, circle_size, circle_size)
-    
+
     # Text
     painter.setPen(Qt.white)
     font_size = size // 3
     font = QFont("Arial", font_size, QFont.Bold)
     painter.setFont(font)
     painter.drawText(pixmap.rect(), Qt.AlignCenter, "W")
-    
+
     painter.end()
-    
+
     return QIcon(pixmap)

--- a/src/witticism/ui/icon_utils.py
+++ b/src/witticism/ui/icon_utils.py
@@ -1,0 +1,48 @@
+from PyQt5.QtGui import QIcon, QPixmap, QPainter, QFont, QColor
+from PyQt5.QtCore import Qt
+
+
+def create_witticism_icon(size: int = 64, color: str = "green") -> QIcon:
+    """Create the Witticism icon programmatically.
+    
+    Args:
+        size: Icon size in pixels
+        color: Icon color ("green", "red", "yellow", "gray", "orange")
+    
+    Returns:
+        QIcon: The generated icon
+    """
+    pixmap = QPixmap(size, size)
+    pixmap.fill(Qt.transparent)
+    
+    painter = QPainter(pixmap)
+    painter.setRenderHint(QPainter.Antialiasing)
+    
+    # Map color names to QColor
+    color_map = {
+        "green": QColor(76, 175, 80),
+        "red": QColor(244, 67, 54),
+        "yellow": QColor(255, 193, 7),
+        "gray": QColor(158, 158, 158),
+        "orange": QColor(255, 152, 0)
+    }
+    
+    # Calculate circle dimensions based on size
+    margin = size // 8
+    circle_size = size - (2 * margin)
+    
+    # Background circle
+    painter.setBrush(color_map.get(color, QColor(76, 175, 80)))
+    painter.setPen(Qt.NoPen)
+    painter.drawEllipse(margin, margin, circle_size, circle_size)
+    
+    # Text
+    painter.setPen(Qt.white)
+    font_size = size // 3
+    font = QFont("Arial", font_size, QFont.Bold)
+    painter.setFont(font)
+    painter.drawText(pixmap.rect(), Qt.AlignCenter, "W")
+    
+    painter.end()
+    
+    return QIcon(pixmap)

--- a/src/witticism/ui/settings_dialog.py
+++ b/src/witticism/ui/settings_dialog.py
@@ -14,7 +14,8 @@ class SettingsDialog(QDialog):
         self.config_manager = config_manager
         self.setWindowTitle("Settings")
         self.setWindowIcon(create_witticism_icon())
-        self.setFixedSize(650, 700)
+        self.resize(800, 850)
+        self.setMinimumSize(600, 650)
         self.init_ui()
         self.load_current_settings()
 

--- a/src/witticism/ui/settings_dialog.py
+++ b/src/witticism/ui/settings_dialog.py
@@ -4,6 +4,7 @@ from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel,
                              QDialogButtonBox, QDoubleSpinBox)
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QKeySequence
+from witticism.ui.icon_utils import create_witticism_icon
 
 class SettingsDialog(QDialog):
     settings_changed = pyqtSignal(dict)
@@ -12,7 +13,8 @@ class SettingsDialog(QDialog):
         super().__init__(parent)
         self.config_manager = config_manager
         self.setWindowTitle("Settings")
-        self.setFixedSize(450, 500)
+        self.setWindowIcon(create_witticism_icon())
+        self.setFixedSize(650, 700)
         self.init_ui()
         self.load_current_settings()
 


### PR DESCRIPTION
## Summary

This PR addresses UI improvements for the Settings and About dialogs, making them more readable with appropriate window sizes. It also adds desktop integration features to make Witticism available in the application launcher.

## Changes

### Dialog Window Improvements
- **Settings Dialog**: Increased size from 450x500 to 650x700 pixels for better readability
- **About Dialog**: Increased size from 500x400 to 700x550 pixels for better content display
- **Window Icons**: Added Witticism icon to both dialogs so they appear properly in the taskbar

### Desktop Integration Features
- Created reusable icon generation utility (`icon_utils.py`)
- Added desktop entry file for application launchers
- Created installation/uninstallation scripts for desktop integration
- Added icon generation script for multiple sizes (16x16 to 512x512)
- Updated README with desktop integration instructions

## Testing

- [x] Verified dialog windows are now readable at new sizes
- [x] Confirmed window icons appear in taskbar
- [x] Tested desktop entry installation script
- [x] Verified icon generation at multiple sizes

## Screenshots

The dialogs now have appropriate sizes for comfortable reading and interaction, and the Witticism icon appears in the taskbar when dialogs are open.

## Installation

After merging, users can optionally install desktop integration with:
```bash
./scripts/install_desktop_entry.sh
```

This will add Witticism to their application launcher with proper icons.