### PR TITLE
Fix: Display actual configured hotkeys in UI

### DIFF
--- a/src/witticism/ui/about_dialog.py
+++ b/src/witticism/ui/about_dialog.py
@@ -2,8 +2,7 @@ import sys
 from pathlib import Path
 from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel,
                              QPushButton, QTextBrowser, QTabWidget, QWidget)
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QPixmap, QFont
+from PyQt5.QtGui import QFont
 import importlib.metadata
 from witticism.ui.icon_utils import create_witticism_icon
 

--- a/src/witticism/ui/about_dialog.py
+++ b/src/witticism/ui/about_dialog.py
@@ -66,14 +66,14 @@ class AboutDialog(QDialog):
         about_layout = QVBoxLayout()
         about_text = QTextBrowser()
         about_text.setOpenExternalLinks(True)
-        
+
         # Get current hotkey settings
         ptt_key = "F9"  # Default
         mode_switch_key = "Ctrl+Alt+M"  # Default
         if self.config_manager:
             ptt_key = self.config_manager.get("hotkeys.push_to_talk", "F9").upper()
             mode_switch_key = self.config_manager.get("hotkeys.mode_switch", "Ctrl+Alt+M")
-        
+
         about_text.setHtml(f"""
         <p>Witticism is a powerful voice transcription tool that types with your voice anywhere on your system.</p>
 

--- a/src/witticism/ui/about_dialog.py
+++ b/src/witticism/ui/about_dialog.py
@@ -8,8 +8,9 @@ import importlib.metadata
 from witticism.ui.icon_utils import create_witticism_icon
 
 class AboutDialog(QDialog):
-    def __init__(self, parent=None):
+    def __init__(self, config_manager=None, parent=None):
         super().__init__(parent)
+        self.config_manager = config_manager
         self.setWindowTitle("About Witticism")
         self.setWindowIcon(create_witticism_icon())
         self.resize(750, 600)
@@ -66,13 +67,21 @@ class AboutDialog(QDialog):
         about_layout = QVBoxLayout()
         about_text = QTextBrowser()
         about_text.setOpenExternalLinks(True)
-        about_text.setHtml("""
+        
+        # Get current hotkey settings
+        ptt_key = "F9"  # Default
+        mode_switch_key = "Ctrl+Alt+M"  # Default
+        if self.config_manager:
+            ptt_key = self.config_manager.get("hotkeys.push_to_talk", "F9").upper()
+            mode_switch_key = self.config_manager.get("hotkeys.mode_switch", "Ctrl+Alt+M")
+        
+        about_text.setHtml(f"""
         <p>Witticism is a powerful voice transcription tool that types with your voice anywhere on your system.</p>
 
         <h3>Features:</h3>
         <ul>
-            <li><b>Push-to-Talk Mode:</b> Hold F9 to record, release to transcribe</li>
-            <li><b>Toggle Dictation Mode:</b> Press F9 to start/stop continuous transcription</li>
+            <li><b>Push-to-Talk Mode:</b> Hold {ptt_key} to record, release to transcribe</li>
+            <li><b>Toggle Dictation Mode:</b> Press {ptt_key} to start/stop continuous transcription</li>
             <li><b>GPU Acceleration:</b> Uses CUDA for fast transcription when available</li>
             <li><b>Multiple Models:</b> Choose from tiny to large models based on your needs</li>
             <li><b>System Tray Integration:</b> Runs quietly in the background</li>
@@ -80,8 +89,8 @@ class AboutDialog(QDialog):
 
         <h3>Keyboard Shortcuts:</h3>
         <ul>
-            <li><b>F9:</b> Push-to-talk or toggle dictation (depending on mode)</li>
-            <li><b>Ctrl+Alt+M:</b> Switch between push-to-talk and toggle modes</li>
+            <li><b>{ptt_key}:</b> Push-to-talk or toggle dictation (depending on mode)</li>
+            <li><b>{mode_switch_key}:</b> Switch between push-to-talk and toggle modes</li>
         </ul>
 
         <p>Visit <a href="https://github.com/Aaronontheweb/witticism">GitHub</a> for more information.</p>

--- a/src/witticism/ui/hotkey_input_widget.py
+++ b/src/witticism/ui/hotkey_input_widget.py
@@ -1,6 +1,6 @@
 from PyQt5.QtWidgets import (QWidget, QHBoxLayout, QPushButton,
                              QKeySequenceEdit, QLabel)
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtGui import QKeySequence
 
 class HotkeyInputWidget(QWidget):

--- a/src/witticism/ui/settings_dialog.py
+++ b/src/witticism/ui/settings_dialog.py
@@ -1,7 +1,6 @@
 from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel,
                              QComboBox, QSlider,
-                             QGroupBox, QFormLayout, QKeySequenceEdit,
-                             QDialogButtonBox, QDoubleSpinBox)
+                             QGroupBox, QFormLayout, QDialogButtonBox, QDoubleSpinBox)
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QKeySequence
 from witticism.ui.icon_utils import create_witticism_icon

--- a/src/witticism/ui/system_tray.py
+++ b/src/witticism/ui/system_tray.py
@@ -493,7 +493,7 @@ class SystemTrayApp(QSystemTrayIcon):
         ptt_key = "F9"  # Default
         if self.config_manager:
             ptt_key = self.config_manager.get("hotkeys.push_to_talk", "F9").upper()
-        
+
         if mode == "push_to_talk":
             self.ptt_action.setText(f"Push-to-Talk (Hold {ptt_key})")
         else:

--- a/src/witticism/ui/system_tray.py
+++ b/src/witticism/ui/system_tray.py
@@ -89,8 +89,8 @@ class SystemTrayApp(QSystemTrayIcon):
         self.toggle_action.triggered.connect(self.toggle_enabled)
         self.menu.addAction(self.toggle_action)
 
-        # Push-to-talk action
-        self.ptt_action = QAction("Push-to-Talk (Hold F9)", self)
+        # Push-to-talk action (text will be updated later when config is loaded)
+        self.ptt_action = QAction("Push-to-Talk", self)
         self.ptt_action.setEnabled(False)
         self.menu.addAction(self.ptt_action)
 
@@ -490,10 +490,14 @@ class SystemTrayApp(QSystemTrayIcon):
             self.hotkey_manager.set_mode(mode)
 
         # Update PTT action text
+        ptt_key = "F9"  # Default
+        if self.config_manager:
+            ptt_key = self.config_manager.get("hotkeys.push_to_talk", "F9").upper()
+        
         if mode == "push_to_talk":
-            self.ptt_action.setText("Push-to-Talk (Hold F9)")
+            self.ptt_action.setText(f"Push-to-Talk (Hold {ptt_key})")
         else:
-            self.ptt_action.setText("Toggle Dictation (Press F9)")
+            self.ptt_action.setText(f"Toggle Dictation (Press {ptt_key})")
 
         # Stop any ongoing dictation if switching away from toggle mode
         if mode == "push_to_talk" and self.is_dictating:
@@ -620,6 +624,12 @@ class SystemTrayApp(QSystemTrayIcon):
             key_str = settings["hotkeys.push_to_talk"]
             if key_str and self.hotkey_manager.update_hotkey_from_string(key_str, "ptt"):
                 actually_changed = True
+                # Update menu text with new hotkey
+                ptt_key = key_str.upper()
+                if self.mode == "push_to_talk":
+                    self.ptt_action.setText(f"Push-to-Talk (Hold {ptt_key})")
+                else:
+                    self.ptt_action.setText(f"Toggle Dictation (Press {ptt_key})")
 
         # Check which settings actually need restart
         if "audio.sample_rate" in settings:
@@ -651,7 +661,7 @@ class SystemTrayApp(QSystemTrayIcon):
 
     def show_about(self):
         """Show the about dialog"""
-        dialog = AboutDialog()
+        dialog = AboutDialog(config_manager=self.config_manager)
         dialog.exec_()
 
     def on_tray_activated(self, reason):
@@ -695,6 +705,14 @@ class SystemTrayApp(QSystemTrayIcon):
         self.hotkey_manager = hotkey_manager
         self.output_manager = output_manager
         self.config_manager = config_manager
+
+        # Update PTT action text with actual configured hotkey
+        if self.config_manager:
+            ptt_key = self.config_manager.get("hotkeys.push_to_talk", "F9").upper()
+            if self.mode == "push_to_talk":
+                self.ptt_action.setText(f"Push-to-Talk (Hold {ptt_key})")
+            else:
+                self.ptt_action.setText(f"Toggle Dictation (Press {ptt_key})")
 
         # Update device menu now that we have audio_capture
         self.update_device_menu()


### PR DESCRIPTION
## Summary
- Fixes hardcoded F9 display in About dialog and system tray menu
- Shows actual configured hotkeys dynamically throughout the UI

## Changes
- Pass config_manager to AboutDialog to read actual hotkey values
- Update system tray menu to show actual configured push-to-talk key
- Dynamically update menu text when hotkeys are changed in settings
- Remove all hardcoded F9 references from UI

## Test Plan
- Open About dialog - verify it shows actual configured hotkey
- Right-click system tray icon - verify menu shows actual hotkey
- Change hotkey in Settings - verify menu updates immediately
- Switch between push-to-talk and toggle modes - verify text updates correctly