### PR TITLE
Add debug logging documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,18 @@ Should return `True` if CUDA is available.
 ### Models not loading
 First run downloads models (~150MB for base). Ensure stable internet connection.
 
+### Debug logging
+By default, witticism logs to `~/.local/share/witticism/debug.log` when debug level is enabled. 
+
+To enable debug logging, either:
+- Run with `--log-level DEBUG`
+- Edit `~/.config/witticism/config.json` and set `"logging": {"level": "DEBUG", "file": "~/.local/share/witticism/debug.log"}`
+
+Common issues visible in debug logs:
+- "No active speech found in audio" - Check microphone connection/volume
+- CUDA context errors - Restart after suspend/resume
+- Model loading failures - Check GPU memory with `nvidia-smi`
+
 ## Development
 
 ### Project Structure


### PR DESCRIPTION
## Summary
Adds comprehensive debug logging documentation to the troubleshooting section of the README.

## Changes
- Document default log location: `~/.local/share/witticism/debug.log`
- Add instructions for enabling debug logging via CLI (`--log-level DEBUG`) and config file
- Include common debug patterns and troubleshooting guidance for:
  - Microphone connection issues
  - CUDA context errors after suspend/resume
  - Model loading failures and GPU memory issues

## Test plan
- [x] Verified documentation formatting in README
- [x] Confirmed debug logging instructions are accurate
- [x] Tested that log paths and CLI options are correct

This improves user experience by providing clear guidance for troubleshooting common issues.