### PR TITLE
Add PyPI version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Witticism
 
 [![CI](https://github.com/Aaronontheweb/witticism/actions/workflows/ci.yml/badge.svg)](https://github.com/Aaronontheweb/witticism/actions/workflows/ci.yml)
+[![PyPI version](https://img.shields.io/pypi/v/witticism.svg)](https://pypi.org/project/witticism/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)](https://www.python.org/downloads/)
 [![GitHub release](https://img.shields.io/github/release/Aaronontheweb/witticism.svg)](https://github.com/Aaronontheweb/witticism/releases/latest)


### PR DESCRIPTION
## Summary
- Added shields.io badge showing PyPI package version and linking to the witticism package page

## Test plan
- [x] Verify badge displays correctly in README
- [x] Verify badge links to correct PyPI package page