### PR TITLE
Fix install.sh version extraction hanging issue

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -119,7 +119,7 @@ if pipx list | grep -q "package witticism"; then
     echo "✓ Witticism is already installed"
     
     # Get current version
-    CURRENT_VERSION=$(pipx list | grep -A1 "package witticism" | grep "version" | sed 's/.*version \([^,]*\).*/\1/')
+    CURRENT_VERSION=$(pipx list | grep "package witticism" | sed 's/.*package witticism \([^,]*\).*/\1/')
     echo "  Current version: $CURRENT_VERSION"
     
     # Check PyTorch version in the pipx environment


### PR DESCRIPTION
## Summary
- Fixed version extraction command in install.sh that was causing the script to hang
- The original command was looking for a 'version' keyword that doesn't exist in pipx list output
- Changed to extract version directly from the package line format

## Test plan
- [x] Verified the new command works correctly with pipx list output
- [x] Tested that it properly extracts version "0.4.2" from the package line