### PR TITLE
Fix installation failures by removing unused PyGObject dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "pyperclip>=1.8.0",
     "platformdirs>=3.0.0",
     "pydbus>=0.6.0",
-    "PyGObject>=3.40.0",
 ]
 
 


### PR DESCRIPTION
## Summary
- Remove PyGObject dependency from pyproject.toml that was causing installation failures
- PyGObject requires system libraries that were intentionally removed in commit a3f9988
- PyGObject is not used anywhere in the codebase

## Test plan
- [ ] Verify witticism installation/upgrade works without system dependency errors
- [ ] Confirm no code references PyGObject imports

Fixes the upgrade error where pip was trying to build PyGObject from source but failing due to missing girepository-2.0 system dependencies.