### PR TITLE
Fix install script UX - add progress indicators for slow operations

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -317,6 +317,7 @@ if pipx list | grep -q "package witticism"; then
     echo "  Current version: $CURRENT_VERSION"
     
     # Check PyTorch version in the pipx environment
+    echo "  Checking PyTorch compatibility (this may take a moment)..."
     PYTORCH_CHECK=$(pipx run --spec witticism python -c "import torch; print(torch.__version__)" 2>/dev/null || echo "")
     if [ -n "$PYTORCH_CHECK" ]; then
         PYTORCH_VERSION="$PYTORCH_CHECK"
@@ -354,6 +355,7 @@ except:
     if [ "$LATEST_VERSION" != "unknown" ] && [ "$LATEST_VERSION" != "$CURRENT_VERSION" ]; then
         echo "  📦 New version available: $LATEST_VERSION"
         echo "🔄 Upgrading Witticism (preserving compatible PyTorch)..."
+        echo "⏳ This may take several minutes depending on what needs updating..."
         pipx upgrade witticism --pip-args="--index-url $INDEX_URL --extra-index-url https://pypi.org/simple"
     elif [ "$NEEDS_REINSTALL" = true ]; then
         echo "🔄 Reinstalling due to PyTorch compatibility..."


### PR DESCRIPTION
## Summary
- Added progress indicator message before slow PyTorch compatibility check
- Added timing warning for upgrade operations that download large packages
- Prevents users from thinking the script is frozen during 1-2 minute operations

## Problem
The install script would appear to hang for 1-2 minutes when:
1. Checking PyTorch version via `pipx run --spec witticism python -c "import torch"`
2. Downloading/upgrading large packages during installation

This led to users thinking the script was broken when it was actually working correctly.

## Solution
Added simple user feedback messages at these bottleneck points to indicate progress:
- "Checking PyTorch compatibility (this may take a moment)..." 
- "This may take several minutes depending on what needs updating..."

## Test Plan
- [ ] Run install script on a system with witticism already installed
- [ ] Verify progress messages appear during PyTorch check
- [ ] Verify upgrade process shows timing expectations
- [ ] Confirm installation completes successfully