### PR TITLE
Fix PowerShell Get-ChildItem syntax error in icon detection

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -135,9 +135,8 @@ function Get-WitticismPackageInfo {
         if (Test-Path $assetsPath) {
             if ($verbose) {
                 Write-Host "   Available icon files:" -ForegroundColor Gray
-                Get-ChildItem -Path $assetsPath -Name "*.ico", "*.png" | ForEach-Object {
-                    Write-Host "   - $_" -ForegroundColor Gray
-                }
+                Get-ChildItem -Path $assetsPath -Filter "*.ico" | ForEach-Object { Write-Host "   - $($_.Name)" -ForegroundColor Gray }
+                Get-ChildItem -Path $assetsPath -Filter "*.png" | ForEach-Object { Write-Host "   - $($_.Name)" -ForegroundColor Gray }
             }
             
             # First check for .ico file (best for Windows shortcuts)


### PR DESCRIPTION
## Summary
Fixes a PowerShell syntax error in the installer's `Get-WitticismPackageInfo` function that was causing a non-fatal error during icon detection.

## Problem
Line 138 in `install.ps1` had incorrect PowerShell syntax:
```powershell
Get-ChildItem -Path $assetsPath -Name "*.ico", "*.png"
```

This caused a PowerShell error:
```
Cannot convert 'System.Object[]' to the type 'System.String' required by parameter 'Filter'
```

## Solution
Split the command into separate calls for each file type:
```powershell
Get-ChildItem -Path $assetsPath -Filter "*.ico" | ForEach-Object { Write-Host "   - $($_.Name)" -ForegroundColor Gray }
Get-ChildItem -Path $assetsPath -Filter "*.png" | ForEach-Object { Write-Host "   - $($_.Name)" -ForegroundColor Gray }
```

## Impact
- ✅ Eliminates PowerShell syntax error during verbose icon detection
- ✅ Icon detection functionality remains unchanged and working correctly
- ✅ No impact on actual icon setting behavior
- ✅ Improves installer reliability and error-free operation

## Testing
- [x] Verified icon detection function works correctly with fix
- [x] Confirmed ICO file is properly detected and used
- [x] No regression in shortcut creation functionality

This is a minor but important fix that improves the installer's robustness and eliminates confusing error messages during installation.