### PR TITLE
docs: add Windows debug log locations and force reinstall instructions

### DIFF
--- a/INSTALL_WINDOWS.md
+++ b/INSTALL_WINDOWS.md
@@ -81,6 +81,23 @@ After installation:
 4. **System Tray**: Look for Witticism icon in system tray
 5. **Auto-start**: Witticism starts automatically on Windows login
 
+## Important File Locations
+
+After installation, Witticism stores files in the following Windows locations:
+
+- **Configuration**: `%APPDATA%\witticism\config.json` (e.g., `C:\Users\YourName\AppData\Roaming\witticism\config.json`)
+- **Debug logs**: `%LOCALAPPDATA%\witticism\debug.log` (e.g., `C:\Users\YourName\AppData\Local\witticism\debug.log`)
+- **Models cache**: `%USERPROFILE%\.cache\whisper` (downloaded Whisper models)
+
+To view debug logs:
+```powershell
+# Open debug log in Notepad
+notepad "$env:LOCALAPPDATA\witticism\debug.log"
+
+# Or view in PowerShell
+Get-Content "$env:LOCALAPPDATA\witticism\debug.log" -Tail 50
+```
+
 ## Troubleshooting
 
 ### PowerShell Execution Policy

--- a/README.md
+++ b/README.md
@@ -229,16 +229,48 @@ This fix prevents the `nvidia_uvm` kernel module from becoming corrupted during 
 First run downloads models (~150MB for base). Ensure stable internet connection.
 
 ### Debug logging
-By default, witticism logs to `~/.local/share/witticism/debug.log` when debug level is enabled. 
+
+**Log file locations:**
+- **Linux**: `~/.local/share/witticism/debug.log`
+- **Windows**: `%LOCALAPPDATA%\witticism\debug.log` (e.g., `C:\Users\YourName\AppData\Local\witticism\debug.log`)
 
 To enable debug logging, either:
 - Run with `--log-level DEBUG`
-- Edit `~/.config/witticism/config.json` and set `"logging": {"level": "DEBUG", "file": "~/.local/share/witticism/debug.log"}`
+- Edit the config file and set `"logging": {"level": "DEBUG", "file": "<path-to-log-file>"}`
+  - **Linux config**: `~/.config/witticism/config.json`
+  - **Windows config**: `%APPDATA%\witticism\config.json`
 
 Common issues visible in debug logs:
 - "No active speech found in audio" - Check microphone connection/volume
 - CUDA context errors - Restart after suspend/resume
 - Model loading failures - Check GPU memory with `nvidia-smi`
+
+### Force Reinstall
+
+If you need to force a complete reinstallation (e.g., to fix corrupted dependencies or reset settings):
+
+**Linux:**
+```bash
+# Force reinstall with the installer
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/witticism/master/install.sh | bash -s -- --force
+```
+
+**Windows:**
+```powershell
+# Force reinstall with all dependencies
+irm https://raw.githubusercontent.com/Aaronontheweb/witticism/master/install.ps1 | iex -ForceReinstall
+
+# Additional options can be combined:
+# Force CPU-only reinstall without auto-start
+$script = irm https://raw.githubusercontent.com/Aaronontheweb/witticism/master/install.ps1
+& ([scriptblock]::Create($script)) -ForceReinstall -CPUOnly -SkipAutoStart
+```
+
+The force reinstall option will:
+- Remove existing Witticism installation
+- Clear the pipx/pip cache
+- Reinstall all dependencies fresh
+- Preserve your configuration files (unless you use `--reset-config`)
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Added Windows-specific file locations for debug logs and configuration
- Added force reinstall instructions for both Linux and Windows platforms
- Enhanced Windows installation guide with troubleshooting information

## Changes
- **README.md**: 
  - Added Windows debug log location (`%LOCALAPPDATA%\witticism\debug.log`)
  - Added Windows config location (`%APPDATA%\witticism\config.json`)
  - Added force reinstall instructions with examples for both platforms
  
- **INSTALL_WINDOWS.md**:
  - Added "Important File Locations" section
  - Documented how to view debug logs using Notepad or PowerShell
  - Listed all key file locations (config, logs, model cache)

## Purpose
These documentation improvements help Windows users:
1. Find debug logs when troubleshooting issues
2. Perform clean reinstalls when needed
3. Understand where Witticism stores its files on Windows

The force reinstall options are particularly useful for fixing corrupted dependencies or resetting the installation while preserving user configuration.