### PR TITLE
Add transcription pipeline resiliency improvements

### DIFF
--- a/src/witticism/core/audio_capture.py
+++ b/src/witticism/core/audio_capture.py
@@ -75,6 +75,32 @@ class AudioCapture:
         self._last_device_index: Optional[int] = None
 
         logger.info(f"AudioCapture initialized: {sample_rate}Hz, {channels} channel(s)")
+        self._log_default_device_info()
+
+    def _get_device_name(self, device_index: Optional[int]) -> str:
+        """Get human-readable device name from device index."""
+        try:
+            if device_index is None:
+                default_info = self.audio.get_default_input_device_info()
+                return default_info.get('name', 'Default Device')
+            else:
+                device_info = self.audio.get_device_info_by_index(device_index)
+                return device_info.get('name', f'Device {device_index}')
+        except Exception:
+            return f"Device {device_index}" if device_index is not None else "Default Device"
+
+    def _log_default_device_info(self) -> None:
+        """Log default input device information at initialization."""
+        try:
+            default_info = self.audio.get_default_input_device_info()
+            device_name = default_info.get('name', 'Unknown')
+            device_index = default_info.get('index', -1)
+            sample_rate = default_info.get('defaultSampleRate', 'Unknown')
+            channels = default_info.get('maxInputChannels', 'Unknown')
+            logger.info(f"[AUDIO_CAPTURE] DEFAULT_DEVICE: name='{device_name}' (index={device_index}), "
+                       f"sample_rate={sample_rate}, channels={channels}")
+        except Exception as e:
+            logger.warning(f"[AUDIO_CAPTURE] DEFAULT_DEVICE_ERROR: could not get default device info - {e}")
 
     def get_audio_devices(self) -> List[dict]:
         devices = []
@@ -210,7 +236,8 @@ class AudioCapture:
             )
             self.capture_thread.start()
 
-            logger.info(f"Started recording on device {device_index}")
+            device_name = self._get_device_name(device_index)
+            logger.info(f"[AUDIO_CAPTURE] RECORDING_STARTED: device='{device_name}' (index={device_index})")
 
         except Exception as e:
             logger.error(f"Failed to start recording: {e}")
@@ -232,9 +259,10 @@ class AudioCapture:
         # Convert buffer to numpy array
         if self.recording_buffer:
             audio_data = np.concatenate(self.recording_buffer)
-            logger.info(f"Stopped recording. Captured {len(audio_data)/self.sample_rate:.2f} seconds")
+            logger.info(f"[AUDIO_CAPTURE] RECORDING_STOPPED: captured {len(audio_data)/self.sample_rate:.2f} seconds of audio")
             return audio_data
         else:
+            logger.info("[AUDIO_CAPTURE] RECORDING_STOPPED: no audio captured (empty buffer)")
             return np.array([], dtype=np.int16)
 
     def _capture_loop(self, callback: Optional[Callable]) -> None:
@@ -430,7 +458,8 @@ class ContinuousCapture(AudioCapture):
             )
             self.capture_thread.start()
 
-            logger.info(f"Started continuous recording on device {device_index}")
+            device_name = self._get_device_name(device_index)
+            logger.info(f"[AUDIO_CAPTURE] CONTINUOUS_RECORDING_STARTED: device='{device_name}' (index={device_index})")
 
         except Exception as e:
             logger.error(f"Failed to start continuous recording: {e}")

--- a/src/witticism/main.py
+++ b/src/witticism/main.py
@@ -308,12 +308,25 @@ class WitticismApp:
             sample_rate = self.config_manager.get("audio.sample_rate", 16000)
             channels = self.config_manager.get("audio.channels", 1)
             vad_aggressiveness = self.config_manager.get("audio.vad_aggressiveness", 2)
-            logger.info(f"[WITTICISM] AUDIO_INIT: sample_rate={sample_rate}, channels={channels}, vad_aggressiveness={vad_aggressiveness}")
+            configured_device = self.config_manager.get("audio.device_index", None)
+            logger.info(f"[WITTICISM] AUDIO_INIT: sample_rate={sample_rate}, channels={channels}, "
+                       f"vad_aggressiveness={vad_aggressiveness}, configured_device_index={configured_device}")
             self.audio_capture = PushToTalkCapture(
                 sample_rate=sample_rate,
                 channels=channels,
                 vad_aggressiveness=vad_aggressiveness
             )
+
+            # Log available audio devices at DEBUG level (#108)
+            try:
+                devices = self.audio_capture.get_audio_devices()
+                logger.debug(f"[WITTICISM] AUDIO_DEVICES_AVAILABLE: found {len(devices)} input device(s)")
+                for device in devices:
+                    logger.debug(f"[WITTICISM] AUDIO_DEVICE: index={device['index']}, "
+                               f"name='{device['name']}', channels={device['channels']}, "
+                               f"sample_rate={device['sample_rate']}")
+            except Exception as e:
+                logger.warning(f"[WITTICISM] AUDIO_DEVICES_ERROR: could not enumerate audio devices - {e}")
 
             # Initialize transcription pipeline
             min_audio_length = self.config_manager.get("pipeline.min_audio_length", 0.5)

--- a/src/witticism/ui/system_tray.py
+++ b/src/witticism/ui/system_tray.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from PyQt5.QtWidgets import QApplication, QSystemTrayIcon, QMenu, QAction, QMessageBox
 from PyQt5.QtCore import pyqtSignal, QThread, Qt, QTimer
 from PyQt5.QtGui import QIcon, QPixmap
@@ -11,26 +12,42 @@ from witticism.ui.cuda_health_dialog import CudaHealthDialog
 
 logger = logging.getLogger(__name__)
 
+# Default timeout for transcription operations (in seconds)
+TRANSCRIPTION_TIMEOUT = 60
+
 
 class TranscriptionWorker(QThread):
     transcription_complete = pyqtSignal(str)
     transcription_error = pyqtSignal(str)
+    transcription_timeout = pyqtSignal()
     status_update = pyqtSignal(str)
 
-    def __init__(self, engine, audio_data):
+    def __init__(self, engine, audio_data, timeout=TRANSCRIPTION_TIMEOUT):
         super().__init__()
         self.engine = engine
         self.audio_data = audio_data
+        self.timeout = timeout
 
     def run(self):
         try:
             self.status_update.emit("Transcribing...")
-            result = self.engine.transcribe(self.audio_data)
-            text = self.engine.format_result(result)
-            self.transcription_complete.emit(text)
+            # Use ThreadPoolExecutor for timeout protection (#106)
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(self._do_transcription)
+                try:
+                    text = future.result(timeout=self.timeout)
+                    self.transcription_complete.emit(text)
+                except FuturesTimeoutError:
+                    logger.error(f"[TRANSCRIPTION] TIMEOUT: transcription exceeded {self.timeout}s timeout")
+                    self.transcription_timeout.emit()
         except Exception as e:
             logger.error(f"Transcription error: {e}")
             self.transcription_error.emit(str(e))
+
+    def _do_transcription(self) -> str:
+        """Perform the actual transcription work (can be interrupted by timeout)."""
+        result = self.engine.transcribe(self.audio_data)
+        return self.engine.format_result(result)
 
 
 class SystemTrayApp(QSystemTrayIcon):
@@ -50,6 +67,12 @@ class SystemTrayApp(QSystemTrayIcon):
         self.is_dictating = False  # For toggle mode
         self.mode = "push_to_talk"  # "push_to_talk" or "toggle"
         self.cuda_error_shown = False  # Track if we've shown CUDA error notification
+
+        # No-speech detection tracking (#107, #109)
+        self.consecutive_no_speech_count = 0
+        self.no_speech_threshold = 3  # Show notification after this many consecutive no-speech events
+        self.no_speech_notification_shown = False
+        self.no_speech_cooldown_timer = None
 
         self.init_ui()
         self.set_status("Ready")
@@ -430,14 +453,20 @@ class SystemTrayApp(QSystemTrayIcon):
         self.worker = TranscriptionWorker(self.engine, audio_float)
         self.worker.transcription_complete.connect(self.on_transcription_complete)
         self.worker.transcription_error.connect(self.on_transcription_error)
+        self.worker.transcription_timeout.connect(self.on_transcription_timeout)
         self.worker.status_update.connect(self.set_status)
         self.worker.start()
 
     def on_transcription_complete(self, text):
         self.set_status("Ready")
 
-        if text and self.output_manager:
-            self.output_manager.output_text(text)
+        # Track no-speech events (#107, #109)
+        if not text or not text.strip():
+            self._handle_no_speech_event()
+        else:
+            self._reset_no_speech_counter()
+            if self.output_manager:
+                self.output_manager.output_text(text)
 
     def on_transcription_error(self, error):
         self.set_status("Error")
@@ -455,6 +484,83 @@ class SystemTrayApp(QSystemTrayIcon):
 
                 # Update status to reflect CPU mode
                 self.set_status("Ready")
+
+    def on_transcription_timeout(self):
+        """Handle transcription timeout (#106)."""
+        logger.warning("[TRANSCRIPTION] TIMEOUT_HANDLER: transcription operation timed out")
+        self.set_status("Transcription timed out")
+
+        if self.supportsMessages():
+            self.showMessage(
+                "Transcription Timeout",
+                "Transcription took too long and was cancelled.\n"
+                "This may indicate a processing issue.\n"
+                "Try recording a shorter clip.",
+                QSystemTrayIcon.Warning,
+                5000
+            )
+
+        # Reset to ready after a brief delay
+        QTimer.singleShot(3000, lambda: self.set_status("Ready"))
+
+    def _handle_no_speech_event(self):
+        """Track and handle no-speech detection events (#107, #109)."""
+        self.consecutive_no_speech_count += 1
+        logger.info(f"[TRANSCRIPTION] NO_SPEECH: no speech detected "
+                   f"(consecutive count: {self.consecutive_no_speech_count}/{self.no_speech_threshold})")
+
+        # Update status to show no speech was detected
+        self.set_status("No speech detected")
+        QTimer.singleShot(2000, lambda: self.set_status("Ready") if not self.is_recording else None)
+
+        # Check if we've hit the threshold for showing a notification
+        if (self.consecutive_no_speech_count >= self.no_speech_threshold and
+                not self.no_speech_notification_shown):
+            self._show_no_speech_notification()
+
+    def _show_no_speech_notification(self):
+        """Show warning notification about persistent no-speech detection (#109)."""
+        logger.warning(f"[TRANSCRIPTION] NO_SPEECH_PERSISTENT: {self.consecutive_no_speech_count} "
+                      "consecutive recordings with no speech detected")
+
+        self.no_speech_notification_shown = True
+
+        if self.supportsMessages():
+            self.showMessage(
+                "No Speech Detected",
+                "Multiple recordings detected no speech.\n\n"
+                "Please check:\n"
+                "- Microphone is connected and selected\n"
+                "- Microphone is not muted\n"
+                "- You're speaking clearly into the mic",
+                QSystemTrayIcon.Warning,
+                8000
+            )
+
+        # Reset notification flag after cooldown (allow re-showing after 60 seconds)
+        self._reset_no_speech_notification_flag_delayed()
+
+    def _reset_no_speech_counter(self):
+        """Reset no-speech counter on successful transcription."""
+        if self.consecutive_no_speech_count > 0:
+            logger.info(f"[TRANSCRIPTION] SPEECH_DETECTED: resetting no-speech counter "
+                       f"(was {self.consecutive_no_speech_count})")
+        self.consecutive_no_speech_count = 0
+
+    def _reset_no_speech_notification_flag_delayed(self):
+        """Reset notification flag after cooldown to allow re-showing."""
+        if self.no_speech_cooldown_timer:
+            self.no_speech_cooldown_timer.stop()
+
+        self.no_speech_cooldown_timer = QTimer()
+        self.no_speech_cooldown_timer.setSingleShot(True)
+        self.no_speech_cooldown_timer.timeout.connect(self._reset_no_speech_notification_flag)
+        self.no_speech_cooldown_timer.start(60000)  # 60 second cooldown
+
+    def _reset_no_speech_notification_flag(self):
+        """Reset notification flag to allow re-showing after cooldown."""
+        self.no_speech_notification_shown = False
+        logger.debug("[TRANSCRIPTION] NO_SPEECH_COOLDOWN_EXPIRED: notification can be shown again")
 
     def show_cuda_error_notification(self):
         """Show a system tray notification about CUDA error and CPU fallback."""

--- a/src/witticism/utils/logging_config.py
+++ b/src/witticism/utils/logging_config.py
@@ -45,3 +45,18 @@ def setup_logging(
     # Suppress some noisy loggers
     logging.getLogger("pynput").setLevel(logging.WARNING)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+    # Capture PyAnnote VAD warnings (important for #107 - no speech detection)
+    pyannote_logger = logging.getLogger("pyannote")
+    pyannote_logger.setLevel(logging.WARNING)
+
+    # Capture WhisperX warnings (important for transcription issues)
+    whisperx_logger = logging.getLogger("whisperx")
+    whisperx_logger.setLevel(logging.WARNING)
+
+    # Capture faster_whisper warnings
+    faster_whisper_logger = logging.getLogger("faster_whisper")
+    faster_whisper_logger.setLevel(logging.WARNING)
+
+    # Capture Python warnings to logging (helps catch VAD 'no speech found' warnings)
+    logging.captureWarnings(True)


### PR DESCRIPTION
## Summary

This PR adds several improvements to make the transcription pipeline more resilient and user-friendly:

- **Timeout protection (#106)**: Wrap transcription in ThreadPoolExecutor with 60-second timeout to prevent indefinite hangs. Shows warning notification on timeout.
- **VAD warning logging (#107)**: Capture third-party library warnings from pyannote, whisperx, and faster_whisper. Track consecutive no-speech events and show status updates.
- **Audio device logging (#108)**: Add `_get_device_name()` helper to resolve device indices to human-readable names. Log default device info at initialization. Log available devices at DEBUG level.
- **No-speech detection (#109)**: After 3 consecutive no-speech transcriptions, show warning notification with troubleshooting suggestions. Includes 60-second cooldown before re-showing notification.

Closes #106, closes #107, closes #108, closes #109

## Test plan

- [ ] Start witticism and verify `~/.local/share/witticism/debug.log` shows actual device name (not "None")
- [ ] Record with mic muted/wrong device, verify "No speech detected" appears in status
- [ ] After 3 no-speech attempts, verify notification appears with troubleshooting suggestions
- [ ] Record with actual speech, verify counter resets and text is output
- [ ] Verify existing pytest tests pass: `pytest tests/ --ignore=tests/test_sleep_monitoring.py`