### PR TITLE
Fix PyTorch 2.6+ startup failure

### DIFF
--- a/src/witticism/core/whisperx_engine.py
+++ b/src/witticism/core/whisperx_engine.py
@@ -11,6 +11,18 @@ try:
     WHISPERX_AVAILABLE = True
     logger = logging.getLogger(__name__)
     logger.info("[WHISPERX_ENGINE] LIBRARY_LOADED: WhisperX library loaded successfully")
+
+    # Fix for PyTorch 2.6+ (issue #105): Add omegaconf types to safe globals
+    # PyTorch 2.6 changed weights_only default to True, breaking WhisperX model loading
+    try:
+        from omegaconf import ListConfig, DictConfig
+        torch.serialization.add_safe_globals([ListConfig, DictConfig])
+        logger.debug("[WHISPERX_ENGINE] PYTORCH26_FIX: added omegaconf types to torch safe globals")
+    except ImportError:
+        logger.debug("[WHISPERX_ENGINE] PYTORCH26_FIX: omegaconf not available, skipping safe globals setup")
+    except AttributeError:
+        # PyTorch < 2.6 doesn't have add_safe_globals
+        logger.debug("[WHISPERX_ENGINE] PYTORCH26_FIX: torch.serialization.add_safe_globals not available (PyTorch < 2.6)")
 except ImportError:
     from . import mock_whisperx as whisperx
     WHISPERX_AVAILABLE = False
@@ -366,6 +378,10 @@ class WhisperXEngine:
     def is_loading(self) -> bool:
         """Check if models are currently loading."""
         return self.loading_thread is not None and self.loading_thread.is_alive()
+
+    def is_loaded(self) -> bool:
+        """Check if models are loaded and ready for transcription."""
+        return self.model is not None
 
     def get_loading_progress(self) -> Tuple[str, int]:
         """Get current loading status and progress percentage."""


### PR DESCRIPTION
## Summary

Fixes startup failures when using PyTorch 2.6 or later.

### #105 - PyTorch 2.6+ startup failure
- PyTorch 2.6 changed `weights_only` default to `True` in `torch.load()`
- WhisperX models contain `omegaconf.ListConfig` and `DictConfig` objects not in the default safe globals
- **Fix**: Add omegaconf types to `torch.serialization.add_safe_globals()` before any model loading

### #102 - Missing `is_loaded()` method causing crash
- The suspend handler in `_on_system_suspend()` called `self.is_loaded()` but the method didn't exist
- This caused an `AttributeError` crash when Windows suspend was detected
- **Fix**: Add `is_loaded()` method that returns `True` if the transcription model is loaded

Closes #102, closes #105

## Test plan

- [ ] Verify app starts successfully with PyTorch 2.6+ (test on Windows with PyTorch 2.7.1)
- [ ] Verify suspend/resume doesn't crash with missing `is_loaded()` method
- [ ] Run unit tests: `pytest tests/ --ignore=tests/test_sleep_monitoring.py`