### PR TITLE
Add ContainerMetadata to PyTorch 2.6+ safe globals

### DIFF
--- a/src/witticism/core/whisperx_engine.py
+++ b/src/witticism/core/whisperx_engine.py
@@ -12,18 +12,17 @@ try:
     logger = logging.getLogger(__name__)
     logger.info("[WHISPERX_ENGINE] LIBRARY_LOADED: WhisperX library loaded successfully")
 
-    # Fix for PyTorch 2.6+ (issue #105): Add omegaconf types to safe globals
-    # PyTorch 2.6 changed weights_only default to True, breaking WhisperX model loading
-    try:
-        from omegaconf import ListConfig, DictConfig
-        from omegaconf.base import ContainerMetadata
-        torch.serialization.add_safe_globals([ListConfig, DictConfig, ContainerMetadata])
-        logger.debug("[WHISPERX_ENGINE] PYTORCH26_FIX: added omegaconf types to torch safe globals")
-    except ImportError:
-        logger.debug("[WHISPERX_ENGINE] PYTORCH26_FIX: omegaconf not available, skipping safe globals setup")
-    except AttributeError:
-        # PyTorch < 2.6 doesn't have add_safe_globals
-        logger.debug("[WHISPERX_ENGINE] PYTORCH26_FIX: torch.serialization.add_safe_globals not available (PyTorch < 2.6)")
+    # Fix for PyTorch 2.6+ (issue #105): Override weights_only default back to False
+    # PyTorch 2.6 changed weights_only default to True, breaking WhisperX/pyannote model loading.
+    # Allowlisting individual types is a losing game — the models use too many dynamic types
+    # (omegaconf, typing.Any, etc). Since we only load trusted local model checkpoints,
+    # patching torch.load to default weights_only=False is the pragmatic fix.
+    _original_torch_load = torch.load
+    def _patched_torch_load(*args, **kwargs):
+        kwargs['weights_only'] = False
+        return _original_torch_load(*args, **kwargs)
+    torch.load = _patched_torch_load
+    logger.debug("[WHISPERX_ENGINE] PYTORCH26_FIX: patched torch.load to default weights_only=False")
 except ImportError:
     from . import mock_whisperx as whisperx
     WHISPERX_AVAILABLE = False

--- a/src/witticism/core/whisperx_engine.py
+++ b/src/witticism/core/whisperx_engine.py
@@ -16,7 +16,8 @@ try:
     # PyTorch 2.6 changed weights_only default to True, breaking WhisperX model loading
     try:
         from omegaconf import ListConfig, DictConfig
-        torch.serialization.add_safe_globals([ListConfig, DictConfig])
+        from omegaconf.base import ContainerMetadata
+        torch.serialization.add_safe_globals([ListConfig, DictConfig, ContainerMetadata])
         logger.debug("[WHISPERX_ENGINE] PYTORCH26_FIX: added omegaconf types to torch safe globals")
     except ImportError:
         logger.debug("[WHISPERX_ENGINE] PYTORCH26_FIX: omegaconf not available, skipping safe globals setup")


### PR DESCRIPTION
## Summary
- Replaces the `add_safe_globals` allowlist approach with a `torch.load` monkey-patch that forces `weights_only=False`
- The allowlist approach was a losing game — whisperx and pyannote load models with many dynamic types (`omegaconf`, `typing.Any`, etc.) and pyannote explicitly passes `weights_only=True`
- Since we only load trusted local model checkpoints, this is safe and pragmatic
- Follow-up to #113 / #105

## Test plan
- [x] Launch witticism after `pipx install --force` and verify no initialization error
- [x] Verify all models load (transcription + alignment)
- [x] Verify PTT transcription works end-to-end