### PR TITLE
Harden Wayland platform adapters (review follow-ups to #125)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,19 @@ jobs:
     - name: Install minimal test dependencies
       run: |
         python -m pip install --upgrade pip
-        # Non-GPU dependencies needed to exercise the platform adapter and
-        # config/CLI tests. pytest runs the pytest-style adapter tests that
-        # `unittest discover` silently skipped, plus the unittest-style tests.
-        pip install pytest dbus-next platformdirs pyperclip pynput
+        # Non-GPU dependencies needed to exercise the platform adapter, config,
+        # CLI, and system-tray tests. PyQt5 lets the tray tests import and run
+        # headless under QT_QPA_PLATFORM=offscreen; numpy is pulled in by the
+        # tray's transcriber import. pytest runs both pytest-style and
+        # unittest-style tests.
+        pip install pytest dbus-next platformdirs pyperclip pynput PyQt5 numpy
 
     - name: Run all unit tests
+      env:
+        # Make the src-layout package importable without relying on a test file's
+        # sys.path side effect, and run Qt headless.
+        PYTHONPATH: src
+        QT_QPA_PLATFORM: offscreen
       run: |
         # pytest natively runs both unittest-style and pytest-style tests.
         python -m pytest tests/ -v

--- a/src/witticism/core/hotkey_manager.py
+++ b/src/witticism/core/hotkey_manager.py
@@ -10,6 +10,7 @@ from witticism.platform.input_output import (
     ShortcutTrigger,
     create_shortcut_adapter,
 )
+from witticism.utils.config_manager import is_usable_accelerator
 
 logger = logging.getLogger(__name__)
 DEFAULT_PTT_DEBOUNCE_MS = 30
@@ -43,6 +44,9 @@ class HotkeyManager:
         # listener) and the debounce Timer thread, so a fresh press racing a
         # firing stop-timer cannot corrupt the recording state.
         self._state_lock = threading.Lock()
+        # Set when a mode switch stops an active hold whose key may still be
+        # physically down; the next push_to_talk release is then swallowed.
+        self._pending_ptt_release = False
         self._last_toggle_press = 0.0
         # Backends that cannot observe key-release (e.g. a GNOME custom
         # keyboard shortcut) advertise supports_hold=False; the manager then
@@ -119,10 +123,15 @@ class HotkeyManager:
                 if self.mode != "push_to_talk":
                     return
                 self._cancel_ptt_stop_timer()
-                if self._begin_ptt() and self.on_push_to_talk_start:
-                    self.on_push_to_talk_start()
+                self._begin_ptt()
                 return
             if event.type != ShortcutEventType.DEACTIVATED:
+                return
+            if self._pending_ptt_release:
+                # A leftover physical key-release from a capture we already
+                # stopped on a mode switch (the key was still held). Consume it
+                # so it does not fall through and flip dictation on.
+                self._pending_ptt_release = False
                 return
             if not self.supports_hold:
                 # Press-to-toggle backends never emit release events; ignore any.
@@ -154,29 +163,41 @@ class HotkeyManager:
     def _toggle_ptt_press(self):
         if not self._toggle_debounced():
             return
-        if self._begin_ptt():
-            if self.on_push_to_talk_start:
-                self.on_push_to_talk_start()
-        elif self._end_ptt():
-            if self.on_push_to_talk_stop:
-                self.on_push_to_talk_stop()
+        # Alternate start/stop; each transition fires its own callback under the
+        # lock (see _begin_ptt / _end_ptt).
+        if not self._begin_ptt():
+            self._end_ptt()
 
     def _begin_ptt(self):
-        """Atomically transition into recording. Returns True only for the call
-        that made the transition, which should then fire on_push_to_talk_start."""
+        """Atomically transition into recording and fire on_push_to_talk_start.
+
+        Returns True only for the call that made the transition. The callback is
+        fired while the lock is held so that, when a fresh press races a firing
+        stop-timer on another thread, the start/stop notifications reach
+        listeners in the same order as the underlying state transitions. The
+        callbacks only enqueue a Qt signal (or, in tests, do trivial work), so
+        holding the lock across them is cheap and cannot re-enter these methods.
+        """
         with self._state_lock:
             if self.ptt_active:
                 return False
             self.ptt_active = True
+            if self.on_push_to_talk_start:
+                self.on_push_to_talk_start()
             return True
 
     def _end_ptt(self):
-        """Atomically transition out of recording. Returns True only for the
-        call that made the transition, which should fire on_push_to_talk_stop."""
+        """Atomically transition out of recording and fire on_push_to_talk_stop.
+
+        Returns True only for the call that made the transition. See _begin_ptt
+        for why the callback fires under the lock.
+        """
         with self._state_lock:
             if not self.ptt_active:
                 return False
             self.ptt_active = False
+            if self.on_push_to_talk_stop:
+                self.on_push_to_talk_stop()
             return True
 
     def _toggle_dictation_press(self):
@@ -206,8 +227,7 @@ class HotkeyManager:
     def _do_ptt_stop(self):
         with self._ptt_timer_lock:
             self._ptt_stop_timer = None
-        if self._end_ptt() and self.on_push_to_talk_stop:
-            self.on_push_to_talk_stop()
+        self._end_ptt()
 
     def update_hotkey_from_string(self, key_string: str, hotkey_type: str = "ptt"):
         if hotkey_type != "ptt" or not self._valid_ptt_key(key_string):
@@ -230,13 +250,13 @@ class HotkeyManager:
     def _accel_or_default(value, default):
         """Coerce a configured accelerator to a usable string.
 
-        A null/number/empty value (from a hand-edited or partially-migrated
-        config) would otherwise reach the accelerator parser, which raises on a
-        non-string. Fall back to the default so a bad config disables nothing.
+        A null/number/empty/modifier-only value (from a hand-edited or
+        partially-migrated config) would otherwise reach the accelerator parser,
+        which raises on a non-string. Uses the same usability rule as the config
+        migration (is_usable_accelerator) so the two cannot diverge; falls back
+        to the default so a bad config disables nothing.
         """
-        if isinstance(value, str) and value.strip():
-            return value
-        return default
+        return value if is_usable_accelerator(value) else default
 
     def set_mode(self, mode: str):
         if mode not in ("push_to_talk", "toggle"):
@@ -252,7 +272,11 @@ class HotkeyManager:
         # pinned at RECORDING.
         if self.mode == "push_to_talk" and mode == "toggle":
             self._cancel_ptt_stop_timer()
-            self._do_ptt_stop()
+            # Stop the in-flight capture. On a hold-capable backend the physical
+            # key may still be down, so remember that its release is coming and
+            # must not be misread as a dictation toggle once we are in toggle mode.
+            if self._end_ptt() and self.supports_hold:
+                self._pending_ptt_release = True
         old = self.mode
         self.mode = mode
         logger.info("[HOTKEY_MANAGER] MODE_CHANGED: from %s to %s", old, mode)

--- a/src/witticism/core/hotkey_manager.py
+++ b/src/witticism/core/hotkey_manager.py
@@ -43,13 +43,17 @@ class HotkeyManager:
         self.dictation_active = False
         self.ptt_debounce_ms = int(self._configured("hotkeys.ptt_debounce_ms", DEFAULT_PTT_DEBOUNCE_MS))
         self._ptt_stop_timer: Optional[threading.Timer] = None
-        self._ptt_timer_lock = threading.Lock()
-        # Guards ptt_active across the shortcut-event thread (D-Bus/pynput
-        # listener) and the debounce Timer thread, so a fresh press racing a
-        # firing stop-timer cannot corrupt the recording state.
-        self._state_lock = threading.Lock()
-        # Set when a mode switch stops an active hold whose key may still be
-        # physically down; the next push_to_talk release is then swallowed.
+        # One reentrant lock serializes ALL shortcut-state mutation across the
+        # three threads that touch it - the shortcut-event handler (D-Bus/pynput
+        # listener), the debounce Timer, and set_mode (GUI thread) - so a
+        # release, a firing stop-timer, and a mode switch can never interleave.
+        # Reentrant so the transition helpers can re-acquire it under a caller
+        # that already holds it. All of ptt_active, mode, dictation_active,
+        # _pending_ptt_release and _ptt_stop_timer are mutated only under it.
+        self._state_lock = threading.RLock()
+        # Set when a mode switch stops an in-progress hold whose key is still
+        # physically down; the next push_to_talk release is then swallowed so it
+        # does not flip dictation on.
         self._pending_ptt_release = False
         self._last_toggle_press = 0.0
         # Backends that cannot observe key-release (e.g. a GNOME custom
@@ -102,62 +106,62 @@ class HotkeyManager:
 
     def stop(self):
         self._cancel_ptt_stop_timer()
-        if self.ptt_active:
-            self._do_ptt_stop()
+        self._do_ptt_stop()  # no-op if not recording
         self.adapter.stop()
         self.listener = None
         logger.info("[HOTKEY_MANAGER] STOPPED")
 
     def _on_shortcut_event(self, event: ShortcutEvent):
+        # Serialize the whole handler against set_mode and the debounce Timer, so
+        # release / stop-timer / mode-switch can never interleave. The lock is
+        # reentrant, so the transition helpers may re-acquire it.
         try:
-            if event.id == "mode_switch" and event.type == ShortcutEventType.ACTIVATED:
-                if self.on_toggle:
-                    self.on_toggle()
-                return
-            if event.id != "push_to_talk":
-                return
-            if event.type == ShortcutEventType.ACTIVATED:
-                if not self.supports_hold:
-                    # Press-only backend: the ACTIVATED press is the only signal
-                    # we ever get, so drive both modes from it. push_to_talk
-                    # alternates start/stop; toggle flips continuous dictation.
-                    if self.mode == "push_to_talk":
-                        self._toggle_ptt_press()
-                    elif self.mode == "toggle":
-                        self._toggle_dictation_press()
-                    return
-                if self.mode != "push_to_talk":
-                    return
-                self._cancel_ptt_stop_timer()
-                self._begin_ptt()
-                return
-            if event.type != ShortcutEventType.DEACTIVATED:
-                return
-            if not self.supports_hold:
-                # Press-to-toggle backends never emit release events; ignore any.
-                return
-            if self.mode == "push_to_talk":
-                # A real release always ends the capture. The stray-release guard
-                # is intentionally NOT applied here: swallowing a release in
-                # push-to-talk mode could leave the mic stuck recording. If the
-                # mode-switch race delivered the armed release here (mode not yet
-                # flipped), it lands harmlessly (ptt_active already False); consume
-                # the pending-swallow so it cannot strand and eat a later toggle.
-                self._pending_ptt_release = False
-                if self.ptt_active:
-                    self._schedule_ptt_stop() if self.ptt_debounce_ms > 0 else self._do_ptt_stop()
-            elif self.mode == "toggle":
-                if self._pending_ptt_release:
-                    # A leftover release from a hold we already stopped on the
-                    # mode switch (the key was still down). Consume this one so it
-                    # does not flip dictation on. One-shot; cleared here.
-                    self._pending_ptt_release = False
-                    return
-                self.dictation_active = not self.dictation_active
-                if self.on_toggle_dictation:
-                    self.on_toggle_dictation(self.dictation_active)
+            with self._state_lock:
+                self._handle_shortcut_event(event)
         except Exception:
             logger.exception("[HOTKEY_MANAGER] SHORTCUT_EVENT_ERROR")
+
+    def _handle_shortcut_event(self, event: ShortcutEvent):
+        if event.id == "mode_switch" and event.type == ShortcutEventType.ACTIVATED:
+            if self.on_toggle:
+                self.on_toggle()
+            return
+        if event.id != "push_to_talk":
+            return
+        if event.type == ShortcutEventType.ACTIVATED:
+            if not self.supports_hold:
+                # Press-only backend: the ACTIVATED press is the only signal we
+                # ever get, so drive both modes from it. push_to_talk alternates
+                # start/stop; toggle flips continuous dictation.
+                if self.mode == "push_to_talk":
+                    self._toggle_ptt_press()
+                elif self.mode == "toggle":
+                    self._toggle_dictation_press()
+                return
+            if self.mode != "push_to_talk":
+                return
+            self._cancel_ptt_stop_timer()
+            self._begin_ptt()
+            return
+        if event.type != ShortcutEventType.DEACTIVATED:
+            return
+        if not self.supports_hold:
+            # Press-to-toggle backends never emit release events; ignore any.
+            return
+        if self.mode == "push_to_talk":
+            # A real release always ends the capture.
+            if self.ptt_active:
+                self._schedule_ptt_stop() if self.ptt_debounce_ms > 0 else self._do_ptt_stop()
+        elif self.mode == "toggle":
+            if self._pending_ptt_release:
+                # Leftover release from a hold we stopped on the mode switch (the
+                # key was still down). Consume it so it does not flip dictation
+                # on. One-shot; armed and consumed under the same lock.
+                self._pending_ptt_release = False
+                return
+            self.dictation_active = not self.dictation_active
+            if self.on_toggle_dictation:
+                self.on_toggle_dictation(self.dictation_active)
 
     def _press_to_toggle_debounce_ms(self):
         # Press-to-toggle needs a much larger guard than hold-to-talk's release
@@ -240,7 +244,7 @@ class HotkeyManager:
             self.on_toggle_dictation(self.dictation_active)
 
     def _schedule_ptt_stop(self):
-        with self._ptt_timer_lock:
+        with self._state_lock:
             if self._ptt_stop_timer is not None:
                 self._ptt_stop_timer.cancel()
             self._ptt_stop_timer = threading.Timer(self.ptt_debounce_ms / 1000.0, self._do_ptt_stop)
@@ -248,15 +252,18 @@ class HotkeyManager:
             self._ptt_stop_timer.start()
 
     def _cancel_ptt_stop_timer(self):
-        with self._ptt_timer_lock:
+        with self._state_lock:
             if self._ptt_stop_timer is not None:
                 self._ptt_stop_timer.cancel()
                 self._ptt_stop_timer = None
 
     def _do_ptt_stop(self):
-        with self._ptt_timer_lock:
+        # Null the timer AND end the capture atomically, so no other thread can
+        # observe the timer cleared while ptt_active is still True (which would
+        # misread a completed utterance as in-progress and discard it).
+        with self._state_lock:
             self._ptt_stop_timer = None
-        self._end_ptt()
+            self._end_ptt()
 
     def update_hotkey_from_string(self, key_string: str, hotkey_type: str = "ptt"):
         if hotkey_type != "ptt" or not self._valid_ptt_key(key_string):
@@ -290,37 +297,34 @@ class HotkeyManager:
     def set_mode(self, mode: str):
         if mode not in ("push_to_talk", "toggle"):
             raise ValueError(f"Invalid mode: {mode}")
-        if self.mode == "toggle" and mode == "push_to_talk":
-            # The stray-release guard only has meaning in toggle mode; clear it so
-            # it can never strand across a switch back and swallow a real release.
-            self._pending_ptt_release = False
-            if self.dictation_active:
-                self.dictation_active = False
-                if self.on_toggle_dictation:
-                    self.on_toggle_dictation(False)
-        # Symmetric to the above: leaving push-to-talk with a capture in flight
-        # must stop it. Otherwise the in-flight press never gets its matching
-        # release (subsequent ACTIVATED events route to dictation), so ptt_active
-        # stays set, the mic keeps recording until shutdown, and tray health is
-        # pinned at RECORDING.
-        if self.mode == "push_to_talk" and mode == "toggle":
-            # A pending debounce stop-timer means the release already arrived and
-            # the key is physically up, so no further release is coming; only arm
-            # the swallow when the key is genuinely still held.
-            with self._ptt_timer_lock:
+        # Hold the shared lock across the entire transition so a shortcut release
+        # or a firing stop-timer cannot interleave with the commit/cancel
+        # decision, the swallow-arm, and the mode flip - they move as one unit.
+        with self._state_lock:
+            old = self.mode
+            if old == "toggle" and mode == "push_to_talk":
+                # The stray-release guard only has meaning in toggle mode; clear
+                # it so it can never strand across a switch back.
+                self._pending_ptt_release = False
+                if self.dictation_active:
+                    self.dictation_active = False
+                    if self.on_toggle_dictation:
+                        self.on_toggle_dictation(False)
+            elif old == "push_to_talk" and mode == "toggle":
+                # Leaving push-to-talk with a capture in flight must end it, or
+                # the in-flight press never gets its matching release and the mic
+                # records until shutdown. A pending debounce stop-timer means the
+                # key was already released (a COMPLETED utterance waiting out the
+                # debounce) - commit it. Otherwise the key is still held (an
+                # in-progress partial) - discard it and swallow the trailing
+                # release so it does not flip dictation on.
                 release_already_seen = self._ptt_stop_timer is not None
                 if self._ptt_stop_timer is not None:
                     self._ptt_stop_timer.cancel()
                     self._ptt_stop_timer = None
-            if release_already_seen:
-                # The key was already released: this is a COMPLETED utterance
-                # waiting out the debounce window. Commit it (transcribe) rather
-                # than discard - a finished utterance must not be lost.
-                self._end_ptt()
-            elif self._cancel_ptt() and self.supports_hold:
-                # Key still held: an in-progress partial capture. Discard it, and
-                # swallow the trailing release so it does not flip dictation on.
-                self._pending_ptt_release = True
-        old = self.mode
-        self.mode = mode
+                if release_already_seen:
+                    self._end_ptt()
+                elif self._cancel_ptt() and self.supports_hold:
+                    self._pending_ptt_release = True
+            self.mode = mode
         logger.info("[HOTKEY_MANAGER] MODE_CHANGED: from %s to %s", old, mode)

--- a/src/witticism/core/hotkey_manager.py
+++ b/src/witticism/core/hotkey_manager.py
@@ -28,6 +28,10 @@ class HotkeyManager:
         self.listener = None
         self.on_push_to_talk_start: Optional[Callable] = None
         self.on_push_to_talk_stop: Optional[Callable] = None
+        # Fired when an in-flight capture is abandoned (not finished) - currently
+        # when a mode switch cancels it. Listeners should drop the audio without
+        # transcribing, distinct from on_push_to_talk_stop which commits it.
+        self.on_push_to_talk_cancel: Optional[Callable] = None
         self.on_toggle: Optional[Callable] = None
         self.on_toggle_dictation: Optional[Callable] = None
         self.ptt_key = self._accel_or_default(self._configured("hotkeys.push_to_talk", "f9"), "f9")
@@ -73,11 +77,13 @@ class HotkeyManager:
         on_push_to_talk_stop=None,
         on_toggle=None,
         on_toggle_dictation=None,
+        on_push_to_talk_cancel=None,
     ):
         self.on_push_to_talk_start = on_push_to_talk_start
         self.on_push_to_talk_stop = on_push_to_talk_stop
         self.on_toggle = on_toggle
         self.on_toggle_dictation = on_toggle_dictation
+        self.on_push_to_talk_cancel = on_push_to_talk_cancel
 
     def start(self):
         if self.listener:
@@ -127,18 +133,22 @@ class HotkeyManager:
                 return
             if event.type != ShortcutEventType.DEACTIVATED:
                 return
-            if self._pending_ptt_release:
-                # A leftover physical key-release from a capture we already
-                # stopped on a mode switch (the key was still held). Consume it
-                # so it does not fall through and flip dictation on.
-                self._pending_ptt_release = False
-                return
             if not self.supports_hold:
                 # Press-to-toggle backends never emit release events; ignore any.
                 return
-            if self.mode == "push_to_talk" and self.ptt_active:
-                self._schedule_ptt_stop() if self.ptt_debounce_ms > 0 else self._do_ptt_stop()
+            if self.mode == "push_to_talk":
+                # A real release always ends the capture. The stray-release guard
+                # is intentionally NOT applied here: swallowing a release in
+                # push-to-talk mode could leave the mic stuck recording.
+                if self.ptt_active:
+                    self._schedule_ptt_stop() if self.ptt_debounce_ms > 0 else self._do_ptt_stop()
             elif self.mode == "toggle":
+                if self._pending_ptt_release:
+                    # A leftover release from a hold we already stopped on the
+                    # mode switch (the key was still down). Consume this one so it
+                    # does not flip dictation on. One-shot; cleared here.
+                    self._pending_ptt_release = False
+                    return
                 self.dictation_active = not self.dictation_active
                 if self.on_toggle_dictation:
                     self.on_toggle_dictation(self.dictation_active)
@@ -197,6 +207,21 @@ class HotkeyManager:
                 return False
             self.ptt_active = False
             if self.on_push_to_talk_stop:
+                self.on_push_to_talk_stop()
+            return True
+
+    def _cancel_ptt(self):
+        """Abandon an in-flight capture (mode switch): clear ptt_active and fire
+        on_push_to_talk_cancel so the buffered audio is dropped, not transcribed.
+        Falls back to on_push_to_talk_stop only if no cancel handler is wired.
+        Returns True only for the call that made the transition."""
+        with self._state_lock:
+            if not self.ptt_active:
+                return False
+            self.ptt_active = False
+            if self.on_push_to_talk_cancel:
+                self.on_push_to_talk_cancel()
+            elif self.on_push_to_talk_stop:
                 self.on_push_to_talk_stop()
             return True
 
@@ -261,21 +286,31 @@ class HotkeyManager:
     def set_mode(self, mode: str):
         if mode not in ("push_to_talk", "toggle"):
             raise ValueError(f"Invalid mode: {mode}")
-        if self.mode == "toggle" and mode == "push_to_talk" and self.dictation_active:
-            self.dictation_active = False
-            if self.on_toggle_dictation:
-                self.on_toggle_dictation(False)
+        if self.mode == "toggle" and mode == "push_to_talk":
+            # The stray-release guard only has meaning in toggle mode; clear it so
+            # it can never strand across a switch back and swallow a real release.
+            self._pending_ptt_release = False
+            if self.dictation_active:
+                self.dictation_active = False
+                if self.on_toggle_dictation:
+                    self.on_toggle_dictation(False)
         # Symmetric to the above: leaving push-to-talk with a capture in flight
         # must stop it. Otherwise the in-flight press never gets its matching
         # release (subsequent ACTIVATED events route to dictation), so ptt_active
         # stays set, the mic keeps recording until shutdown, and tray health is
         # pinned at RECORDING.
         if self.mode == "push_to_talk" and mode == "toggle":
-            self._cancel_ptt_stop_timer()
-            # Stop the in-flight capture. On a hold-capable backend the physical
-            # key may still be down, so remember that its release is coming and
-            # must not be misread as a dictation toggle once we are in toggle mode.
-            if self._end_ptt() and self.supports_hold:
+            # A pending debounce stop-timer means the release already arrived and
+            # the key is physically up, so no further release is coming; only arm
+            # the swallow when the key is genuinely still held.
+            with self._ptt_timer_lock:
+                release_already_seen = self._ptt_stop_timer is not None
+                if self._ptt_stop_timer is not None:
+                    self._ptt_stop_timer.cancel()
+                    self._ptt_stop_timer = None
+            # Cancel (discard) rather than stop (transcribe): a mode switch is not
+            # a finished utterance, so the partial capture is dropped.
+            if self._cancel_ptt() and self.supports_hold and not release_already_seen:
                 self._pending_ptt_release = True
         old = self.mode
         self.mode = mode

--- a/src/witticism/core/hotkey_manager.py
+++ b/src/witticism/core/hotkey_manager.py
@@ -29,14 +29,20 @@ class HotkeyManager:
         self.on_push_to_talk_stop: Optional[Callable] = None
         self.on_toggle: Optional[Callable] = None
         self.on_toggle_dictation: Optional[Callable] = None
-        self.ptt_key = self._configured("hotkeys.push_to_talk", "f9")
-        self.mode_switch_key = self._configured("hotkeys.mode_switch", "Ctrl+Alt+M")
+        self.ptt_key = self._accel_or_default(self._configured("hotkeys.push_to_talk", "f9"), "f9")
+        self.mode_switch_key = self._accel_or_default(
+            self._configured("hotkeys.mode_switch", "Ctrl+Alt+M"), "Ctrl+Alt+M"
+        )
         self.ptt_active = False
         self.mode = "push_to_talk"
         self.dictation_active = False
         self.ptt_debounce_ms = int(self._configured("hotkeys.ptt_debounce_ms", DEFAULT_PTT_DEBOUNCE_MS))
         self._ptt_stop_timer: Optional[threading.Timer] = None
         self._ptt_timer_lock = threading.Lock()
+        # Guards ptt_active across the shortcut-event thread (D-Bus/pynput
+        # listener) and the debounce Timer thread, so a fresh press racing a
+        # firing stop-timer cannot corrupt the recording state.
+        self._state_lock = threading.Lock()
         self._last_toggle_press = 0.0
         # Backends that cannot observe key-release (e.g. a GNOME custom
         # keyboard shortcut) advertise supports_hold=False; the manager then
@@ -113,10 +119,8 @@ class HotkeyManager:
                 if self.mode != "push_to_talk":
                     return
                 self._cancel_ptt_stop_timer()
-                if not self.ptt_active:
-                    self.ptt_active = True
-                    if self.on_push_to_talk_start:
-                        self.on_push_to_talk_start()
+                if self._begin_ptt() and self.on_push_to_talk_start:
+                    self.on_push_to_talk_start()
                 return
             if event.type != ShortcutEventType.DEACTIVATED:
                 return
@@ -150,14 +154,30 @@ class HotkeyManager:
     def _toggle_ptt_press(self):
         if not self._toggle_debounced():
             return
-        if not self.ptt_active:
-            self.ptt_active = True
+        if self._begin_ptt():
             if self.on_push_to_talk_start:
                 self.on_push_to_talk_start()
-        else:
-            self.ptt_active = False
+        elif self._end_ptt():
             if self.on_push_to_talk_stop:
                 self.on_push_to_talk_stop()
+
+    def _begin_ptt(self):
+        """Atomically transition into recording. Returns True only for the call
+        that made the transition, which should then fire on_push_to_talk_start."""
+        with self._state_lock:
+            if self.ptt_active:
+                return False
+            self.ptt_active = True
+            return True
+
+    def _end_ptt(self):
+        """Atomically transition out of recording. Returns True only for the
+        call that made the transition, which should fire on_push_to_talk_stop."""
+        with self._state_lock:
+            if not self.ptt_active:
+                return False
+            self.ptt_active = False
+            return True
 
     def _toggle_dictation_press(self):
         # Toggle (continuous dictation) mode on a press-only backend: each press
@@ -186,10 +206,8 @@ class HotkeyManager:
     def _do_ptt_stop(self):
         with self._ptt_timer_lock:
             self._ptt_stop_timer = None
-        if self.ptt_active:
-            self.ptt_active = False
-            if self.on_push_to_talk_stop:
-                self.on_push_to_talk_stop()
+        if self._end_ptt() and self.on_push_to_talk_stop:
+            self.on_push_to_talk_stop()
 
     def update_hotkey_from_string(self, key_string: str, hotkey_type: str = "ptt"):
         if hotkey_type != "ptt" or not self._valid_ptt_key(key_string):
@@ -208,8 +226,17 @@ class HotkeyManager:
         upper = key_string.upper()
         return upper in {f"F{i}" for i in range(1, 13)} | {"SPACE", "TAB", "ENTER", "ESC"} or len(key_string) == 1
 
-    def change_ptt_key(self, key):
-        return self.update_hotkey_from_string(str(getattr(key, "name", key)))
+    @staticmethod
+    def _accel_or_default(value, default):
+        """Coerce a configured accelerator to a usable string.
+
+        A null/number/empty value (from a hand-edited or partially-migrated
+        config) would otherwise reach the accelerator parser, which raises on a
+        non-string. Fall back to the default so a bad config disables nothing.
+        """
+        if isinstance(value, str) and value.strip():
+            return value
+        return default
 
     def set_mode(self, mode: str):
         if mode not in ("push_to_talk", "toggle"):
@@ -218,6 +245,14 @@ class HotkeyManager:
             self.dictation_active = False
             if self.on_toggle_dictation:
                 self.on_toggle_dictation(False)
+        # Symmetric to the above: leaving push-to-talk with a capture in flight
+        # must stop it. Otherwise the in-flight press never gets its matching
+        # release (subsequent ACTIVATED events route to dictation), so ptt_active
+        # stays set, the mic keeps recording until shutdown, and tray health is
+        # pinned at RECORDING.
+        if self.mode == "push_to_talk" and mode == "toggle":
+            self._cancel_ptt_stop_timer()
+            self._do_ptt_stop()
         old = self.mode
         self.mode = mode
         logger.info("[HOTKEY_MANAGER] MODE_CHANGED: from %s to %s", old, mode)

--- a/src/witticism/core/hotkey_manager.py
+++ b/src/witticism/core/hotkey_manager.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import threading
 import time
@@ -218,19 +219,15 @@ class HotkeyManager:
                 self.on_push_to_talk_stop()
             return True
 
-    def _cancel_ptt(self):
-        """Abandon an in-flight capture (mode switch): clear ptt_active and fire
-        on_push_to_talk_cancel so the buffered audio is dropped, not transcribed.
-        Falls back to on_push_to_talk_stop only if no cancel handler is wired.
-        Returns True only for the call that made the transition."""
+    def _flip_ptt_off(self):
+        """Flip ptt_active to False under the lock and report whether this call
+        made the transition. Fires no callback: set_mode runs the commit/cancel
+        callback AFTER releasing the lock, so blocking teardown never stalls the
+        listener/Timer threads waiting on the lock."""
         with self._state_lock:
             if not self.ptt_active:
                 return False
             self.ptt_active = False
-            if self.on_push_to_talk_cancel:
-                self.on_push_to_talk_cancel()
-            elif self.on_push_to_talk_stop:
-                self.on_push_to_talk_stop()
             return True
 
     def _toggle_dictation_press(self):
@@ -297,9 +294,13 @@ class HotkeyManager:
     def set_mode(self, mode: str):
         if mode not in ("push_to_talk", "toggle"):
             raise ValueError(f"Invalid mode: {mode}")
-        # Hold the shared lock across the entire transition so a shortcut release
-        # or a firing stop-timer cannot interleave with the commit/cancel
-        # decision, the swallow-arm, and the mode flip - they move as one unit.
+        # Decide + flip the state under the lock so a shortcut release or a
+        # firing stop-timer cannot interleave with the commit/cancel decision,
+        # the swallow-arm, and the mode flip - they move as one unit. But run the
+        # resulting callback (which, on the GUI thread, synchronously tears down
+        # audio and joins worker threads) AFTER releasing the lock, so the lock
+        # is never held across blocking teardown.
+        deferred = None
         with self._state_lock:
             old = self.mode
             if old == "toggle" and mode == "push_to_talk":
@@ -309,7 +310,7 @@ class HotkeyManager:
                 if self.dictation_active:
                     self.dictation_active = False
                     if self.on_toggle_dictation:
-                        self.on_toggle_dictation(False)
+                        deferred = functools.partial(self.on_toggle_dictation, False)
             elif old == "push_to_talk" and mode == "toggle":
                 # Leaving push-to-talk with a capture in flight must end it, or
                 # the in-flight press never gets its matching release and the mic
@@ -322,9 +323,14 @@ class HotkeyManager:
                 if self._ptt_stop_timer is not None:
                     self._ptt_stop_timer.cancel()
                     self._ptt_stop_timer = None
-                if release_already_seen:
-                    self._end_ptt()
-                elif self._cancel_ptt() and self.supports_hold:
-                    self._pending_ptt_release = True
+                if self._flip_ptt_off():
+                    if release_already_seen:
+                        deferred = self.on_push_to_talk_stop        # commit (transcribe)
+                    else:
+                        if self.supports_hold:
+                            self._pending_ptt_release = True
+                        deferred = self.on_push_to_talk_cancel or self.on_push_to_talk_stop
             self.mode = mode
+        if deferred:
+            deferred()
         logger.info("[HOTKEY_MANAGER] MODE_CHANGED: from %s to %s", old, mode)

--- a/src/witticism/core/hotkey_manager.py
+++ b/src/witticism/core/hotkey_manager.py
@@ -139,7 +139,11 @@ class HotkeyManager:
             if self.mode == "push_to_talk":
                 # A real release always ends the capture. The stray-release guard
                 # is intentionally NOT applied here: swallowing a release in
-                # push-to-talk mode could leave the mic stuck recording.
+                # push-to-talk mode could leave the mic stuck recording. If the
+                # mode-switch race delivered the armed release here (mode not yet
+                # flipped), it lands harmlessly (ptt_active already False); consume
+                # the pending-swallow so it cannot strand and eat a later toggle.
+                self._pending_ptt_release = False
                 if self.ptt_active:
                     self._schedule_ptt_stop() if self.ptt_debounce_ms > 0 else self._do_ptt_stop()
             elif self.mode == "toggle":
@@ -308,9 +312,14 @@ class HotkeyManager:
                 if self._ptt_stop_timer is not None:
                     self._ptt_stop_timer.cancel()
                     self._ptt_stop_timer = None
-            # Cancel (discard) rather than stop (transcribe): a mode switch is not
-            # a finished utterance, so the partial capture is dropped.
-            if self._cancel_ptt() and self.supports_hold and not release_already_seen:
+            if release_already_seen:
+                # The key was already released: this is a COMPLETED utterance
+                # waiting out the debounce window. Commit it (transcribe) rather
+                # than discard - a finished utterance must not be lost.
+                self._end_ptt()
+            elif self._cancel_ptt() and self.supports_hold:
+                # Key still held: an in-progress partial capture. Discard it, and
+                # swallow the trailing release so it does not flip dictation on.
                 self._pending_ptt_release = True
         old = self.mode
         self.mode = mode

--- a/src/witticism/main.py
+++ b/src/witticism/main.py
@@ -358,11 +358,15 @@ class WitticismApp:
 
     def setup_connections(self):
         # Connect hotkey manager to system tray
+        # Route through the tray's request_* wrappers, which emit Qt signals so
+        # the handlers run on the GUI thread. Hotkey callbacks fire on the D-Bus
+        # runtime / debounce Timer thread, where touching widgets directly is
+        # unsafe.
         self.hotkey_manager.set_callbacks(
-            on_push_to_talk_start=self.tray_app.start_recording,
-            on_push_to_talk_stop=self.tray_app.stop_recording,
-            on_toggle=self.tray_app.toggle_enabled,
-            on_toggle_dictation=self.tray_app.toggle_dictation
+            on_push_to_talk_start=self.tray_app.request_ptt_start,
+            on_push_to_talk_stop=self.tray_app.request_ptt_stop,
+            on_toggle=self.tray_app.request_toggle_enabled,
+            on_toggle_dictation=self.tray_app.request_toggle_dictation
         )
 
         # Pass components to tray app

--- a/src/witticism/main.py
+++ b/src/witticism/main.py
@@ -366,7 +366,8 @@ class WitticismApp:
             on_push_to_talk_start=self.tray_app.request_ptt_start,
             on_push_to_talk_stop=self.tray_app.request_ptt_stop,
             on_toggle=self.tray_app.request_toggle_enabled,
-            on_toggle_dictation=self.tray_app.request_toggle_dictation
+            on_toggle_dictation=self.tray_app.request_toggle_dictation,
+            on_push_to_talk_cancel=self.tray_app.request_ptt_cancel
         )
 
         # Pass components to tray app

--- a/src/witticism/platform/input_output.py
+++ b/src/witticism/platform/input_output.py
@@ -617,19 +617,23 @@ def _build_control_interface(dispatch):
 
 
 def _require_primary_owner(reply, name):
-    """Raise unless ``reply`` from ``request_name`` is PRIMARY_OWNER.
+    """Raise unless we own ``name`` after ``request_name``.
 
     dbus-next's ``request_name`` queues (rather than fails) when the well-known
     name is already taken, and callers ignoring the reply would then run behind
-    a squatter that the GNOME extension's own sender check would trust. Refuse
-    to operate in that case.
+    whoever holds it - a squatter the GNOME extension's own sender check would
+    trust, or (more commonly) a still-running/hung earlier instance whose stale
+    owner would silently swallow our shortcut triggers. Refuse to operate in
+    that case. PRIMARY_OWNER (we took it) and ALREADY_OWNER (we held it on this
+    connection) both mean we own it and are fine.
     """
     from dbus_next import RequestNameReply
 
-    if reply != RequestNameReply.PRIMARY_OWNER:
+    if reply not in (RequestNameReply.PRIMARY_OWNER, RequestNameReply.ALREADY_OWNER):
         raise RuntimeError(
-            f"Another process already owns {name} (request_name returned {reply!r}); "
-            "refusing to run alongside a possible D-Bus name squatter"
+            f"Could not take ownership of {name} (request_name returned {reply!r}); "
+            "another Witticism instance may already be running, or another process "
+            "holds the name. Refusing to run behind it"
         )
 
 

--- a/src/witticism/platform/input_output.py
+++ b/src/witticism/platform/input_output.py
@@ -520,10 +520,14 @@ class GnomeShellShortcutAdapter(ShortcutAdapter):
 
     async def _initialize(self):
         try:
+            from dbus_next import NameFlag
             from dbus_next.aio import MessageBus
 
             bus = await MessageBus().connect()
-            await bus.request_name(APP_BUS)
+            reply = await bus.request_name(APP_BUS, NameFlag.DO_NOT_QUEUE)
+            # The extension trusts whoever owns APP_BUS; if we cannot own it
+            # outright, refuse rather than run behind a squatter.
+            _require_primary_owner(reply, APP_BUS)
             introspection = await bus.introspect(GNOME_BUS, GNOME_PATH)
             obj = bus.get_proxy_object(GNOME_BUS, GNOME_PATH, introspection)
             self.interface = obj.get_interface(GNOME_INTERFACE)
@@ -596,7 +600,8 @@ def _build_control_interface(dispatch):
 
     dbus-next's service machinery is imported lazily so this module stays
     importable without dbus-next. ``dispatch`` is called with the shortcut id
-    each time a registered keybinding fires ``gdbus ... TriggerShortcut``.
+    and a caller-supplied token each time a registered keybinding fires
+    ``gdbus ... TriggerShortcut``; the adapter checks the token before acting.
     """
     from dbus_next.service import ServiceInterface, method
 
@@ -605,10 +610,27 @@ def _build_control_interface(dispatch):
             super().__init__(APP_CONTROL_INTERFACE)
 
         @method()
-        def TriggerShortcut(self, shortcut_id: "s"):  # noqa: F821 - dbus-next type
-            dispatch(shortcut_id)
+        def TriggerShortcut(self, shortcut_id: "s", token: "s"):  # noqa: F821 - dbus-next type
+            dispatch(shortcut_id, token)
 
     return _WitticismControl()
+
+
+def _require_primary_owner(reply, name):
+    """Raise unless ``reply`` from ``request_name`` is PRIMARY_OWNER.
+
+    dbus-next's ``request_name`` queues (rather than fails) when the well-known
+    name is already taken, and callers ignoring the reply would then run behind
+    a squatter that the GNOME extension's own sender check would trust. Refuse
+    to operate in that case.
+    """
+    from dbus_next import RequestNameReply
+
+    if reply != RequestNameReply.PRIMARY_OWNER:
+        raise RuntimeError(
+            f"Another process already owns {name} (request_name returned {reply!r}); "
+            "refusing to run alongside a possible D-Bus name squatter"
+        )
 
 
 def _parse_uint(text, default):
@@ -720,6 +742,14 @@ class GnomeKeybindingShortcutAdapter(ShortcutAdapter):
         self.bus = None
         self._control = None
         self._tracker = None
+        # Per-process secret embedded in the registered gsettings command and
+        # required on every TriggerShortcut call, so a co-resident process
+        # cannot key the microphone on/off just by calling the well-known D-Bus
+        # method. The secret lives in the (same-UID-readable) gsettings command
+        # value, so this raises the bar against opportunistic/cross-app callers
+        # rather than defending against a determined same-UID attacker, which is
+        # not achievable on the session bus.
+        self._trigger_secret = uuid.uuid4().hex
         # Read the keyboard repeat settings up front (before HotkeyManager reads
         # supports_hold at construction). Injectable for tests.
         if keyboard_repeat is None:
@@ -824,10 +854,13 @@ class GnomeKeybindingShortcutAdapter(ShortcutAdapter):
     async def _export_control(self):
         from dbus_next.aio import MessageBus
 
+        from dbus_next import NameFlag
+
         self.bus = await MessageBus().connect()
         self._control = _build_control_interface(self._dispatch_trigger)
         self.bus.export(APP_OBJECT_PATH, self._control)
-        await self.bus.request_name(APP_BUS)
+        reply = await self.bus.request_name(APP_BUS, NameFlag.DO_NOT_QUEUE)
+        _require_primary_owner(reply, APP_BUS)
         logger.info("[PLATFORM_ADAPTER] GNOME keybinding control interface exported")
 
     async def _teardown_control(self):
@@ -845,7 +878,13 @@ class GnomeKeybindingShortcutAdapter(ShortcutAdapter):
         except Exception:
             pass
 
-    def _dispatch_trigger(self, shortcut_id):
+    def _dispatch_trigger(self, shortcut_id, token=None):
+        if token != self._trigger_secret:
+            logger.warning(
+                "[PLATFORM_ADAPTER] Rejecting TriggerShortcut with an invalid token "
+                "(id=%s); ignoring unauthenticated caller", shortcut_id
+            )
+            return
         if shortcut_id not in self._binding_ids:
             logger.debug("[PLATFORM_ADAPTER] Ignoring unknown TriggerShortcut id: %s", shortcut_id)
             return
@@ -883,13 +922,15 @@ class GnomeKeybindingShortcutAdapter(ShortcutAdapter):
     def _is_witticism_path(path):
         return path.startswith(f"{GNOME_CUSTOM_KEYBINDING_BASE}witticism-")
 
-    @staticmethod
-    def _trigger_command(binding_id):
+    def _trigger_command(self, binding_id):
+        # binding_id is always one of two hardcoded literals and the secret is
+        # hex, so both are shell-safe; the command is run by gnome-settings-daemon
+        # via word-splitting, never through /bin/sh -c.
         return (
             "gdbus call --session "
             f"--dest {APP_BUS} "
             f"--object-path {APP_OBJECT_PATH} "
-            f"--method {APP_CONTROL_INTERFACE}.TriggerShortcut {binding_id}"
+            f"--method {APP_CONTROL_INTERFACE}.TriggerShortcut {binding_id} {self._trigger_secret}"
         )
 
     def _read_custom_keybindings(self):
@@ -1114,6 +1155,9 @@ class RemoteDesktopTypeAdapter(TextOutputAdapter):
         self.interface = None
         self.session = None
         self.ready = False
+        # Serializes _type_text so two transcripts dictated in quick succession
+        # cannot interleave their keysyms. Created lazily on the runtime loop.
+        self._type_lock = None
         # Optional UI callback fired when automatic typing is lost (revoked from
         # the system indicator, or an injection failed because the session went
         # away) so the tray can re-surface its "Enable automatic typing..." entry.
@@ -1176,6 +1220,12 @@ class RemoteDesktopTypeAdapter(TextOutputAdapter):
         if not token:
             return
         self.token_file.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # mkdir's mode only applies on creation; tighten defensively in case the
+        # state dir already existed with looser permissions.
+        try:
+            os.chmod(self.token_file.parent, 0o700)
+        except OSError:
+            pass
         temporary = self.token_file.with_suffix(".tmp")
         # Create the file 0600 from its first byte (no world-readable window
         # between write and chmod). O_CREAT's mode only applies on creation, so
@@ -1348,13 +1398,18 @@ class RemoteDesktopTypeAdapter(TextOutputAdapter):
         typed characters land everywhere - matching the X11 typing path. Each
         keysym carries its own case/symbol, so no shift modifier is synthesized.
         """
-        delay = self._type_delay_s()
-        for ch in text:
-            keysym = _char_to_keysym(ch)
-            await self.interface.call_notify_keyboard_keysym(self.session, {}, keysym, 1)  # press
-            await self.interface.call_notify_keyboard_keysym(self.session, {}, keysym, 0)  # release
-            if delay:
-                await asyncio.sleep(delay)
+        if self._type_lock is None:
+            # Safe to create here without a lock: _type_text only ever runs on
+            # the single runtime-loop thread.
+            self._type_lock = asyncio.Lock()
+        async with self._type_lock:
+            delay = self._type_delay_s()
+            for ch in text:
+                keysym = _char_to_keysym(ch)
+                await self.interface.call_notify_keyboard_keysym(self.session, {}, keysym, 1)  # press
+                await self.interface.call_notify_keyboard_keysym(self.session, {}, keysym, 0)  # release
+                if delay:
+                    await asyncio.sleep(delay)
 
     async def _close_session(self):
         if not self.bus or not self.session:

--- a/src/witticism/ui/system_tray.py
+++ b/src/witticism/ui/system_tray.py
@@ -65,6 +65,7 @@ class SystemTrayApp(QSystemTrayIcon):
     # emit stays a direct call).
     ptt_start_requested = pyqtSignal()
     ptt_stop_requested = pyqtSignal()
+    ptt_cancel_requested = pyqtSignal()
     toggle_enabled_requested = pyqtSignal()
     toggle_dictation_requested = pyqtSignal(bool)
 
@@ -490,6 +491,17 @@ class SystemTrayApp(QSystemTrayIcon):
             else:
                 self.set_status("Ready")
 
+    def abort_recording(self):
+        """Stop an in-flight push-to-talk capture and DISCARD its audio without
+        transcribing. Used when a mode switch cancels the capture, so a partial
+        utterance is never injected into the focused window."""
+        if not self.is_recording:
+            return
+        self.is_recording = False
+        if self.audio_capture:
+            self.audio_capture.stop_push_to_talk()  # drop the returned buffer
+        self.set_status("Ready")
+
     def process_transcription(self, audio_data):
         if not self.engine:
             self.set_status("Engine not initialized")
@@ -704,6 +716,15 @@ class SystemTrayApp(QSystemTrayIcon):
             self.loading_progress_action.setVisible(False)
             self.cancel_loading_action.setVisible(False)
 
+    def _ptt_key_label(self):
+        """Upper-cased push-to-talk key for display, tolerating a non-string or
+        empty configured value (from a hand-edited or partially-migrated config)
+        so building a menu label never raises."""
+        key = self.config_manager.get("hotkeys.push_to_talk", "F9") if self.config_manager else "F9"
+        if not isinstance(key, str) or not key.strip():
+            key = "F9"
+        return key.upper()
+
     def change_mode(self, mode: str):
         """Switch between push-to-talk and toggle modes"""
         self.mode = mode
@@ -720,9 +741,7 @@ class SystemTrayApp(QSystemTrayIcon):
             self.hotkey_manager.set_mode(mode)
 
         # Update PTT action text
-        ptt_key = "F9"  # Default
-        if self.config_manager:
-            ptt_key = self.config_manager.get("hotkeys.push_to_talk", "F9").upper()
+        ptt_key = self._ptt_key_label()
 
         if mode == "push_to_talk":
             self.ptt_action.setText(f"Push-to-Talk (Hold {ptt_key})")
@@ -733,12 +752,13 @@ class SystemTrayApp(QSystemTrayIcon):
         if mode == "push_to_talk" and self.is_dictating:
             self.stop_dictation()
 
-        # Switching away from push-to-talk with a capture in flight must stop
-        # the mic. When a hotkey manager is present, set_mode() above already did
-        # this synchronously via its stop callback; this is only the fallback for
-        # the no-hotkey-manager case, so the stop is issued in exactly one place.
+        # Switching away from push-to-talk with a capture in flight cancels it
+        # (drops the partial audio; a mode switch is not a finished utterance).
+        # When a hotkey manager is present, set_mode() above already did this
+        # synchronously via its cancel callback; this is only the fallback for
+        # the no-hotkey-manager case, so the abort is issued in exactly one place.
         if mode == "toggle" and self.is_recording and self.hotkey_manager is None:
-            self.stop_recording()
+            self.abort_recording()
 
         logger.info(f"Mode changed to: {mode}")
 
@@ -854,6 +874,9 @@ class SystemTrayApp(QSystemTrayIcon):
 
     def request_ptt_stop(self):
         self.ptt_stop_requested.emit()
+
+    def request_ptt_cancel(self):
+        self.ptt_cancel_requested.emit()
 
     def request_toggle_enabled(self):
         self.toggle_enabled_requested.emit()
@@ -1100,6 +1123,7 @@ class SystemTrayApp(QSystemTrayIcon):
             # Marshal hotkey events onto the GUI thread before they touch widgets.
             self.ptt_start_requested.connect(self.start_recording)
             self.ptt_stop_requested.connect(self.stop_recording)
+            self.ptt_cancel_requested.connect(self.abort_recording)
             self.toggle_enabled_requested.connect(self.toggle_enabled)
             self.toggle_dictation_requested.connect(self.toggle_dictation)
             # Re-evaluate the offer's visibility every time the menu opens so it
@@ -1112,7 +1136,7 @@ class SystemTrayApp(QSystemTrayIcon):
 
         # Update PTT action text with actual configured hotkey
         if self.config_manager:
-            ptt_key = self.config_manager.get("hotkeys.push_to_talk", "F9").upper()
+            ptt_key = self._ptt_key_label()
             if self.mode == "push_to_talk":
                 self.ptt_action.setText(f"Push-to-Talk (Hold {ptt_key})")
             else:

--- a/src/witticism/ui/system_tray.py
+++ b/src/witticism/ui/system_tray.py
@@ -733,11 +733,11 @@ class SystemTrayApp(QSystemTrayIcon):
         if mode == "push_to_talk" and self.is_dictating:
             self.stop_dictation()
 
-        # Symmetric: switching away from push-to-talk with a capture in flight
-        # must stop the mic. The hotkey manager stops it too when its callbacks
-        # are wired, but the tray must not depend on that; stop_recording() is
-        # idempotent, so at most one of the two takes effect.
-        if mode == "toggle" and self.is_recording:
+        # Switching away from push-to-talk with a capture in flight must stop
+        # the mic. When a hotkey manager is present, set_mode() above already did
+        # this synchronously via its stop callback; this is only the fallback for
+        # the no-hotkey-manager case, so the stop is issued in exactly one place.
+        if mode == "toggle" and self.is_recording and self.hotkey_manager is None:
             self.stop_recording()
 
         logger.info(f"Mode changed to: {mode}")

--- a/src/witticism/ui/system_tray.py
+++ b/src/witticism/ui/system_tray.py
@@ -59,6 +59,14 @@ class SystemTrayApp(QSystemTrayIcon):
     # Automatic typing was lost mid-session (revoked from the system indicator,
     # or an injection failed because the session went away); D-Bus thread.
     autopaste_revoked = pyqtSignal()
+    # Hotkey adapter callbacks fire on the D-Bus runtime / debounce Timer
+    # thread. These signals marshal each event onto the GUI thread before any
+    # widget is touched (Qt queues cross-thread signal deliveries; a same-thread
+    # emit stays a direct call).
+    ptt_start_requested = pyqtSignal()
+    ptt_stop_requested = pyqtSignal()
+    toggle_enabled_requested = pyqtSignal()
+    toggle_dictation_requested = pyqtSignal(bool)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -725,6 +733,13 @@ class SystemTrayApp(QSystemTrayIcon):
         if mode == "push_to_talk" and self.is_dictating:
             self.stop_dictation()
 
+        # Symmetric: switching away from push-to-talk with a capture in flight
+        # must stop the mic. The hotkey manager stops it too when its callbacks
+        # are wired, but the tray must not depend on that; stop_recording() is
+        # idempotent, so at most one of the two takes effect.
+        if mode == "toggle" and self.is_recording:
+            self.stop_recording()
+
         logger.info(f"Mode changed to: {mode}")
 
     def toggle_dictation(self, active: bool):
@@ -830,6 +845,21 @@ class SystemTrayApp(QSystemTrayIcon):
             self._autopaste_broken = False
             self._refresh_autopaste_action()
             self.refresh_health()
+
+    # Thread-safe entry points wired to the hotkey manager. Each only emits a
+    # signal, so the real handler always runs on the GUI thread even when the
+    # hotkey event originated on the D-Bus runtime or debounce Timer thread.
+    def request_ptt_start(self):
+        self.ptt_start_requested.emit()
+
+    def request_ptt_stop(self):
+        self.ptt_stop_requested.emit()
+
+    def request_toggle_enabled(self):
+        self.toggle_enabled_requested.emit()
+
+    def request_toggle_dictation(self, active):
+        self.toggle_dictation_requested.emit(bool(active))
 
     def _emit_autopaste_result(self, granted, message):
         """Bridge the adapter's D-Bus-thread callback onto the GUI thread."""
@@ -1067,6 +1097,11 @@ class SystemTrayApp(QSystemTrayIcon):
         try:
             self.autopaste_result.connect(self._on_autopaste_result)
             self.autopaste_revoked.connect(self._on_autopaste_revoked)
+            # Marshal hotkey events onto the GUI thread before they touch widgets.
+            self.ptt_start_requested.connect(self.start_recording)
+            self.ptt_stop_requested.connect(self.stop_recording)
+            self.toggle_enabled_requested.connect(self.toggle_enabled)
+            self.toggle_dictation_requested.connect(self.toggle_dictation)
             # Re-evaluate the offer's visibility every time the menu opens so it
             # reflects the current granted-state, not just the state at startup.
             self.menu.aboutToShow.connect(self._refresh_autopaste_action)

--- a/src/witticism/ui/system_tray.py
+++ b/src/witticism/ui/system_tray.py
@@ -11,6 +11,7 @@ from witticism.ui.settings_dialog import SettingsDialog
 from witticism.ui.cuda_health_dialog import CudaHealthDialog
 from witticism.ui.autopaste_prompt import AutopasteConsent, show_priming_dialog
 from witticism.ui.tray_health import TrayHealth, compute_tray_health
+from witticism.utils.config_manager import is_usable_accelerator
 
 logger = logging.getLogger(__name__)
 
@@ -717,13 +718,26 @@ class SystemTrayApp(QSystemTrayIcon):
             self.cancel_loading_action.setVisible(False)
 
     def _ptt_key_label(self):
-        """Upper-cased push-to-talk key for display, tolerating a non-string or
-        empty configured value (from a hand-edited or partially-migrated config)
-        so building a menu label never raises."""
+        """Upper-cased push-to-talk key for display, tolerating a non-usable
+        configured value (from a hand-edited or partially-migrated config) so
+        building a menu label never raises. Uses the same usability rule as the
+        hotkey manager (is_usable_accelerator) so display and active key agree."""
         key = self.config_manager.get("hotkeys.push_to_talk", "F9") if self.config_manager else "F9"
-        if not isinstance(key, str) or not key.strip():
+        if not is_usable_accelerator(key):
             key = "F9"
         return key.upper()
+
+    def _set_ptt_action_text(self, mode, ptt_key=None):
+        """Set the PTT menu action label for ``mode``. Single source for the
+        label wording (used by change_mode, set_components and settings). Pass
+        ``ptt_key`` to use a specific key string; otherwise the configured key
+        is read via _ptt_key_label()."""
+        if ptt_key is None:
+            ptt_key = self._ptt_key_label()
+        if mode == "push_to_talk":
+            self.ptt_action.setText(f"Push-to-Talk (Hold {ptt_key})")
+        else:
+            self.ptt_action.setText(f"Toggle Dictation (Press {ptt_key})")
 
     def change_mode(self, mode: str):
         """Switch between push-to-talk and toggle modes"""
@@ -741,12 +755,7 @@ class SystemTrayApp(QSystemTrayIcon):
             self.hotkey_manager.set_mode(mode)
 
         # Update PTT action text
-        ptt_key = self._ptt_key_label()
-
-        if mode == "push_to_talk":
-            self.ptt_action.setText(f"Push-to-Talk (Hold {ptt_key})")
-        else:
-            self.ptt_action.setText(f"Toggle Dictation (Press {ptt_key})")
+        self._set_ptt_action_text(mode)
 
         # Stop any ongoing dictation if switching away from toggle mode
         if mode == "push_to_talk" and self.is_dictating:
@@ -998,12 +1007,8 @@ class SystemTrayApp(QSystemTrayIcon):
             key_str = settings["hotkeys.push_to_talk"]
             if key_str and self.hotkey_manager.update_hotkey_from_string(key_str, "ptt"):
                 actually_changed = True
-                # Update menu text with new hotkey
-                ptt_key = key_str.upper()
-                if self.mode == "push_to_talk":
-                    self.ptt_action.setText(f"Push-to-Talk (Hold {ptt_key})")
-                else:
-                    self.ptt_action.setText(f"Toggle Dictation (Press {ptt_key})")
+                # Update menu text with the just-set hotkey (already validated).
+                self._set_ptt_action_text(self.mode, key_str.upper())
             # A rebind updates hotkey_manager.status; re-render health so a
             # failed rebind (unusable adapter) shows the degraded icon.
             self.refresh_health()
@@ -1136,11 +1141,7 @@ class SystemTrayApp(QSystemTrayIcon):
 
         # Update PTT action text with actual configured hotkey
         if self.config_manager:
-            ptt_key = self._ptt_key_label()
-            if self.mode == "push_to_talk":
-                self.ptt_action.setText(f"Push-to-Talk (Hold {ptt_key})")
-            else:
-                self.ptt_action.setText(f"Toggle Dictation (Press {ptt_key})")
+            self._set_ptt_action_text(self.mode)
 
         # Update device menu now that we have audio_capture
         self.update_device_menu()

--- a/src/witticism/utils/config_manager.py
+++ b/src/witticism/utils/config_manager.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Dict, Any
 import platformdirs
@@ -132,24 +133,48 @@ class ConfigManager:
             return False
 
         if "mode_switch" not in hotkeys:
-            hotkeys["mode_switch"] = self._normalize_accelerator(hotkeys["toggle_enable"])
-            logger.info("Migrated hotkeys.toggle_enable to hotkeys.mode_switch")
+            normalized = self._normalize_accelerator(hotkeys["toggle_enable"])
+            # Only carry over a usable accelerator. A legacy value that is not a
+            # non-empty string (null/number from a hand-edited or corrupted
+            # config, or an empty string) is dropped so the default mode_switch
+            # applies on merge, instead of persisting a value that later crashes
+            # accelerator parsing or silently disables the hotkey.
+            if isinstance(normalized, str) and normalized.strip("+ "):
+                hotkeys["mode_switch"] = normalized
+                logger.info("Migrated hotkeys.toggle_enable to hotkeys.mode_switch")
+            else:
+                logger.warning(
+                    "Dropped unusable legacy hotkeys.toggle_enable value %r; "
+                    "using the default mode_switch", hotkeys["toggle_enable"]
+                )
         del hotkeys["toggle_enable"]
         return True
 
     def save_config(self) -> None:
+        tmp_file = self.config_file.with_name(self.config_file.name + ".tmp")
         try:
             # Create config directory if it doesn't exist
             self.config_dir.mkdir(parents=True, exist_ok=True)
 
-            # Save config
-            with open(self.config_file, 'w') as f:
+            # Write to a sibling temp file then atomically replace, so an
+            # interrupted write (crash, power loss, disk full) can never leave a
+            # truncated config.json that resets every setting to defaults on the
+            # next load. The migration on load makes this the first unattended
+            # write most upgrading users hit, so atomicity matters.
+            with open(tmp_file, 'w') as f:
                 json.dump(self.config, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_file, self.config_file)
 
             logger.info(f"Config saved to {self.config_file}")
 
         except Exception as e:
             logger.error(f"Failed to save config: {e}")
+            try:
+                os.unlink(tmp_file)
+            except OSError:
+                pass
 
     def get(self, key: str, default: Any = None) -> Any:
         keys = key.split('.')

--- a/src/witticism/utils/config_manager.py
+++ b/src/witticism/utils/config_manager.py
@@ -9,6 +9,20 @@ import platformdirs
 logger = logging.getLogger(__name__)
 
 
+def is_usable_accelerator(value: Any) -> bool:
+    """Whether ``value`` is a usable accelerator string.
+
+    Single source of truth shared by the config migration and HotkeyManager so
+    the "is this accelerator usable?" decision cannot diverge between them. A
+    value is usable only if it is a string with at least one non-empty
+    ``+``-separated token (tolerating legacy angle brackets). Rejects None,
+    numbers, ``""``, whitespace, and ``"+"``.
+    """
+    if not isinstance(value, str):
+        return False
+    return any(token.strip().strip("<>").strip() for token in value.split("+"))
+
+
 class ConfigManager:
     def __init__(self, app_name: str = "witticism"):
         self.app_name = app_name
@@ -135,11 +149,11 @@ class ConfigManager:
         if "mode_switch" not in hotkeys:
             normalized = self._normalize_accelerator(hotkeys["toggle_enable"])
             # Only carry over a usable accelerator. A legacy value that is not a
-            # non-empty string (null/number from a hand-edited or corrupted
-            # config, or an empty string) is dropped so the default mode_switch
-            # applies on merge, instead of persisting a value that later crashes
-            # accelerator parsing or silently disables the hotkey.
-            if isinstance(normalized, str) and normalized.strip("+ "):
+            # usable string (null/number from a hand-edited or corrupted config,
+            # or an empty/modifier-only value) is dropped so the default
+            # mode_switch applies on merge, instead of persisting a value that
+            # later crashes accelerator parsing or silently disables the hotkey.
+            if is_usable_accelerator(normalized):
                 hotkeys["mode_switch"] = normalized
                 logger.info("Migrated hotkeys.toggle_enable to hotkeys.mode_switch")
             else:

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -172,3 +172,16 @@ class TestConfigMigration(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def test_is_usable_accelerator_predicate():
+    """The single shared predicate used by both migration and HotkeyManager."""
+    from witticism.utils.config_manager import is_usable_accelerator
+    assert is_usable_accelerator("ctrl+alt+m")
+    assert is_usable_accelerator("<ctrl>+<alt>+m")
+    assert is_usable_accelerator("F9")
+    assert not is_usable_accelerator("")
+    assert not is_usable_accelerator("   ")
+    assert not is_usable_accelerator("+")
+    assert not is_usable_accelerator(None)
+    assert not is_usable_accelerator(5)

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -110,6 +110,65 @@ class TestConfigMigration(unittest.TestCase):
         self.assertEqual(config.get("hotkeys.mode_switch"), "keep-me")
         self.assertIsNone(config.get("hotkeys.toggle_enable"))
 
+    def test_null_toggle_enable_falls_back_to_default(self):
+        """A null legacy value must not persist as mode_switch (it would crash
+        accelerator parsing); the default applies instead."""
+        self._write({"hotkeys": {"toggle_enable": None}})
+        config = self._load()
+        self.assertEqual(config.get("hotkeys.mode_switch"), "ctrl+alt+m")
+        self.assertNotIn("toggle_enable", self._on_disk()["hotkeys"])
+
+    def test_non_string_toggle_enable_falls_back_to_default(self):
+        """A numeric legacy value is dropped rather than persisted."""
+        self._write({"hotkeys": {"toggle_enable": 5}})
+        config = self._load()
+        self.assertEqual(config.get("hotkeys.mode_switch"), "ctrl+alt+m")
+        self.assertNotIn("toggle_enable", self._on_disk()["hotkeys"])
+
+    def test_empty_string_toggle_enable_falls_back_to_default(self):
+        """An empty legacy value would be a non-functional binding; drop it."""
+        self._write({"hotkeys": {"toggle_enable": ""}})
+        config = self._load()
+        self.assertEqual(config.get("hotkeys.mode_switch"), "ctrl+alt+m")
+        self.assertNotIn("toggle_enable", self._on_disk()["hotkeys"])
+
+    def test_save_is_atomic_and_leaves_no_temp_file(self):
+        """save_config writes via a temp file + replace, leaving no .tmp behind
+        and always-valid JSON on disk."""
+        config = self._load()
+        config.set("model.size", "large")
+        tmp = self.config_path.with_name(self.config_path.name + ".tmp")
+        self.assertFalse(tmp.exists())
+        # File on disk is complete/valid and reflects the write.
+        self.assertEqual(self._on_disk()["model"]["size"], "large")
+
+    def test_failed_save_does_not_corrupt_existing_config(self):
+        """If the atomic write fails mid-flight, the previous config.json is
+        left intact (os.replace never ran) rather than truncated."""
+        import json as _json
+        config = self._load()
+        config.set("model.size", "base")
+        good = self._on_disk()
+
+        # Force json.dump to blow up partway through the temp write.
+        original_dump = _json.dump
+
+        def exploding_dump(*args, **kwargs):
+            raise OSError("disk full")
+
+        from witticism.utils import config_manager as cm
+        cm.json.dump = exploding_dump
+        try:
+            config.config["model"]["size"] = "large"
+            config.save_config()  # swallowed; must not corrupt the real file
+        finally:
+            cm.json.dump = original_dump
+
+        # The on-disk file is still the last good one, and no temp remains.
+        self.assertEqual(self._on_disk(), good)
+        tmp = self.config_path.with_name(self.config_path.name + ".tmp")
+        self.assertFalse(tmp.exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_platform_adapters.py
+++ b/tests/test_platform_adapters.py
@@ -1443,23 +1443,50 @@ def test_ptt_transition_callbacks_fire_once_under_lock():
     assert events == ["start", "stop"]
 
 
-def test_set_mode_does_not_arm_swallow_after_release_debounce():
-    """If the PTT key was already released (a debounce stop is pending) when the
-    user switches to toggle, no trailing release is coming, so the swallow must
-    NOT be armed - otherwise the first real toggle press would be eaten."""
+def test_set_mode_after_release_debounce_commits_not_discards():
+    """If the key was already released (a completed utterance is waiting out the
+    debounce) when the user switches to toggle, that finished utterance is
+    committed (transcribed), NOT discarded, and no swallow is armed."""
     adapter = FakeShortcutAdapter()  # supports_hold True
     manager = HotkeyManager(DebounceConfig(1000), adapter=adapter)
+    events = []
     flips = []
-    manager.set_callbacks(on_toggle_dictation=lambda active: flips.append(active))
+    manager.set_callbacks(
+        on_push_to_talk_start=lambda: events.append("start"),
+        on_push_to_talk_stop=lambda: events.append("stop"),
+        on_push_to_talk_cancel=lambda: events.append("cancel"),
+        on_toggle_dictation=lambda active: flips.append(active),
+    )
     manager.start()
     adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)    # hold begins
     adapter.emit("push_to_talk", ShortcutEventType.DEACTIVATED)  # release -> debounce stop scheduled
     assert manager.ptt_active is True                            # still within debounce window
     manager.set_mode("toggle")                                  # release already seen
+    assert events == ["start", "stop"]                          # committed, not "cancel"
     assert manager._pending_ptt_release is False
     adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)
     adapter.emit("push_to_talk", ShortcutEventType.DEACTIVATED)
     assert flips == [True]                                       # first toggle NOT swallowed
+
+
+def test_pending_release_not_stranded_by_mode_switch_race():
+    """Simulate the mode-switch race: the armed release is delivered while mode
+    is still push_to_talk. It must be consumed there rather than left armed to
+    swallow the user's first genuine toggle-dictation press."""
+    adapter = FakeShortcutAdapter()  # supports_hold True
+    manager = HotkeyManager(FakeConfig(), adapter=adapter)
+    flips = []
+    manager.set_callbacks(on_toggle_dictation=lambda active: flips.append(active))
+    manager.start()
+    # Intermediate race state: swallow armed, mode not yet flipped.
+    manager._pending_ptt_release = True
+    assert manager.mode == "push_to_talk"
+    adapter.emit("push_to_talk", ShortcutEventType.DEACTIVATED)  # lands in the ptt branch
+    assert manager._pending_ptt_release is False                # consumed, not stranded
+    manager.set_mode("toggle")
+    adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)
+    adapter.emit("push_to_talk", ShortcutEventType.DEACTIVATED)
+    assert flips == [True]                                       # first toggle works
 
 
 def test_switch_out_and_back_does_not_strand_swallow():

--- a/tests/test_platform_adapters.py
+++ b/tests/test_platform_adapters.py
@@ -1196,7 +1196,10 @@ def test_require_primary_owner_accepts_owner_and_rejects_squatter():
     pytest.importorskip("dbus_next")
     from dbus_next import RequestNameReply
 
+    # Owning the name (freshly or already) is fine.
     input_output._require_primary_owner(RequestNameReply.PRIMARY_OWNER, input_output.APP_BUS)
+    input_output._require_primary_owner(RequestNameReply.ALREADY_OWNER, input_output.APP_BUS)
+    # Queued/blocked behind another owner is refused rather than run behind it.
     for reply in (RequestNameReply.IN_QUEUE, RequestNameReply.EXISTS):
         with pytest.raises(RuntimeError):
             input_output._require_primary_owner(reply, input_output.APP_BUS)
@@ -1381,3 +1384,60 @@ def test_store_token_tightens_loose_state_dir(tmp_path):
     adapter._store_token("secret")
 
     assert stat.S_IMODE(state.stat().st_mode) == 0o700
+
+
+# ---------------------------------------------------------------------------
+# set_mode on a hold-capable backend must not let a dangling key-release (the
+# key still held when the user switched modes via the tray) flip dictation on.
+# ---------------------------------------------------------------------------
+
+def test_set_mode_hold_backend_swallows_dangling_release():
+    adapter = FakeShortcutAdapter()  # supports_hold defaults True
+    manager = HotkeyManager(FakeConfig(), adapter=adapter)
+    events = []
+    manager.set_callbacks(
+        on_push_to_talk_start=lambda: events.append("start"),
+        on_push_to_talk_stop=lambda: events.append("stop"),
+        on_toggle_dictation=lambda active: events.append(("dict", active)),
+    )
+    manager.start()
+    adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)   # hold begins
+    assert manager.ptt_active is True
+    manager.set_mode("toggle")                                  # stops the capture
+    assert manager.ptt_active is False
+    adapter.emit("push_to_talk", ShortcutEventType.DEACTIVATED)  # trailing release
+    assert manager.dictation_active is False                    # NOT toggled on
+    assert events == ["start", "stop"]                          # no dictation event
+
+
+def test_hold_backend_toggle_mode_still_flips_dictation_on_release():
+    """The swallow only consumes the one dangling release; a normal toggle-mode
+    press/release still flips dictation."""
+    adapter = FakeShortcutAdapter()  # supports_hold True
+    manager = HotkeyManager(FakeConfig(), adapter=adapter)
+    flips = []
+    manager.set_callbacks(on_toggle_dictation=lambda active: flips.append(active))
+    manager.start()
+    manager.set_mode("toggle")  # nothing active -> no pending release
+    adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)
+    adapter.emit("push_to_talk", ShortcutEventType.DEACTIVATED)
+    assert flips == [True]
+    assert manager.dictation_active is True
+
+
+def test_ptt_transition_callbacks_fire_once_under_lock():
+    """_begin_ptt/_end_ptt fire their callback exactly once per real transition
+    (and inside the state lock, so start/stop cannot be reordered under a race)."""
+    adapter = FakeShortcutAdapter()
+    manager = HotkeyManager(FakeConfig(), adapter=adapter)
+    events = []
+    manager.set_callbacks(
+        on_push_to_talk_start=lambda: events.append("start"),
+        on_push_to_talk_stop=lambda: events.append("stop"),
+    )
+    manager.start()
+    assert manager._begin_ptt() is True
+    assert manager._begin_ptt() is False   # already active: no duplicate start
+    assert manager._end_ptt() is True
+    assert manager._end_ptt() is False     # already stopped: no duplicate stop
+    assert events == ["start", "stop"]

--- a/tests/test_platform_adapters.py
+++ b/tests/test_platform_adapters.py
@@ -319,9 +319,11 @@ def test_token_file_created_0600_without_chmod_window(tmp_path, monkeypatch):
     adapter._store_token("secret")
 
     # The temp file was created 0600 from its first byte (mode passed to os.open),
-    # and no chmod was used (so there is no world-readable window).
+    # so the token file itself has no world-readable window: chmod is never called
+    # on the token file (only, at most, to tighten the parent state directory).
     assert open_modes == [0o600]
-    assert chmod_calls == []
+    assert all(call[0] == adapter.token_file.parent for call in chmod_calls)
+    assert adapter.token_file not in [call[0] for call in chmod_calls]
     assert stat.S_IMODE(adapter.token_file.stat().st_mode) == 0o600
 
 
@@ -673,7 +675,10 @@ def test_keybinding_registration_writes_entries_and_preserves_list(monkeypatch):
     command = next(c for c in sets if ptt in c[2] and c[3] == "command")
     assert "--dest com.stannardlabs.Witticism" in command[4]
     assert "--object-path /com/stannardlabs/Witticism" in command[4]
-    assert command[4].endswith("TriggerShortcut push_to_talk")
+    # The command carries the per-process auth secret as the second argument so
+    # an unauthenticated caller of TriggerShortcut is rejected.
+    assert command[4].endswith(f"TriggerShortcut push_to_talk {adapter._trigger_secret}")
+    assert len(adapter._trigger_secret) >= 16
     binding = next(c for c in sets if ptt in c[2] and c[3] == "binding")
     assert binding[4] == "F9"
     switch = next(c for c in sets if "witticism-mode-switch/" in c[2] and c[3] == "binding")
@@ -791,8 +796,10 @@ def test_keybinding_repeat_disabled_is_press_to_toggle():
     adapter._binding_ids = {"push_to_talk"}
     events = []
     adapter.on_event = events.append
-    adapter._dispatch_trigger("push_to_talk")   # press-only: single ACTIVATED
-    adapter._dispatch_trigger("not_a_binding")  # unknown -> ignored
+    secret = adapter._trigger_secret
+    adapter._dispatch_trigger("push_to_talk", secret)   # press-only: single ACTIVATED
+    adapter._dispatch_trigger("not_a_binding", secret)  # unknown -> ignored
+    adapter._dispatch_trigger("push_to_talk", "wrong")  # bad token -> ignored
     assert [e.id for e in events] == ["push_to_talk"]
     assert events[0].type == ShortcutEventType.ACTIVATED
 
@@ -812,8 +819,10 @@ def test_keybinding_repeat_enabled_supports_hold_and_routes_to_tracker():
     adapter._tracker = _FakeTracker()
     events = []
     adapter.on_event = events.append
-    adapter._dispatch_trigger("push_to_talk")   # routed to tracker, not emitted directly
-    adapter._dispatch_trigger("not_a_binding")  # unknown -> ignored, not routed
+    secret = adapter._trigger_secret
+    adapter._dispatch_trigger("push_to_talk", secret)   # routed to tracker, not emitted directly
+    adapter._dispatch_trigger("not_a_binding", secret)  # unknown -> ignored, not routed
+    adapter._dispatch_trigger("push_to_talk", "wrong")  # bad token -> ignored, not routed
     assert adapter._tracker.seen == ["push_to_talk"]
     assert events == []  # the tracker owns emission
 
@@ -821,9 +830,9 @@ def test_keybinding_repeat_enabled_supports_hold_and_routes_to_tracker():
 def test_keybinding_control_interface_routes_to_dispatch():
     pytest.importorskip("dbus_next")
     received = []
-    control = input_output._build_control_interface(received.append)
-    control.TriggerShortcut("push_to_talk")
-    assert received == ["push_to_talk"]
+    control = input_output._build_control_interface(lambda sid, token: received.append((sid, token)))
+    control.TriggerShortcut("push_to_talk", "secret123")
+    assert received == [("push_to_talk", "secret123")]
 
 
 # ---------------------------------------------------------------------------
@@ -1114,3 +1123,261 @@ def test_parse_uint_ignores_gsettings_type_annotation():
     assert _parse_uint("500", 0) == 500
     assert _parse_uint("", 123) == 123
     assert _parse_uint(None, 123) == 123
+
+
+# ---------------------------------------------------------------------------
+# set_mode must stop an in-flight push-to-talk capture when leaving PTT, or
+# ptt_active stays set, the mic records until shutdown, and tray health pins
+# at RECORDING (regression for the mode-switch-mid-recording bug).
+# ---------------------------------------------------------------------------
+
+def test_set_mode_ptt_to_toggle_stops_active_recording():
+    adapter = FakeNoHoldAdapter()
+    manager = HotkeyManager(FakeConfig(), adapter=adapter)
+    calls = []
+    manager.set_callbacks(
+        on_push_to_talk_start=lambda: calls.append("start"),
+        on_push_to_talk_stop=lambda: calls.append("stop"),
+    )
+    manager.start()
+    adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)  # press-to-toggle start
+    assert manager.ptt_active is True
+    manager.set_mode("toggle")
+    assert manager.ptt_active is False
+    assert calls == ["start", "stop"]
+
+
+def test_set_mode_ptt_to_toggle_is_noop_when_idle():
+    adapter = FakeNoHoldAdapter()
+    manager = HotkeyManager(FakeConfig(), adapter=adapter)
+    calls = []
+    manager.set_callbacks(
+        on_push_to_talk_start=lambda: calls.append("start"),
+        on_push_to_talk_stop=lambda: calls.append("stop"),
+    )
+    manager.start()
+    manager.set_mode("toggle")  # nothing recording -> no spurious stop
+    assert calls == []
+    assert manager.ptt_active is False
+
+
+def test_set_mode_toggle_to_ptt_still_stops_dictation():
+    adapter = FakeNoHoldAdapter()
+    manager = HotkeyManager(FakeConfig(), adapter=adapter)
+    dictation = []
+    manager.set_callbacks(on_toggle_dictation=lambda active: dictation.append(active))
+    manager.start()
+    manager.set_mode("toggle")
+    adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)  # dictation on
+    assert manager.dictation_active is True
+    manager.set_mode("push_to_talk")
+    assert manager.dictation_active is False
+    assert dictation == [True, False]
+
+
+def test_hotkey_manager_coerces_bad_mode_switch_to_default():
+    class _BadConfig:
+        def get(self, key, default=None):
+            if key == "hotkeys.mode_switch":
+                return None  # e.g. a partially-migrated/corrupt config
+            if key == "hotkeys.ptt_debounce_ms":
+                return 1
+            return default
+
+    manager = HotkeyManager(_BadConfig(), adapter=FakeShortcutAdapter())
+    assert manager.mode_switch_key == "Ctrl+Alt+M"  # coerced, not None
+
+
+# ---------------------------------------------------------------------------
+# D-Bus name-ownership guard.
+# ---------------------------------------------------------------------------
+
+def test_require_primary_owner_accepts_owner_and_rejects_squatter():
+    pytest.importorskip("dbus_next")
+    from dbus_next import RequestNameReply
+
+    input_output._require_primary_owner(RequestNameReply.PRIMARY_OWNER, input_output.APP_BUS)
+    for reply in (RequestNameReply.IN_QUEUE, RequestNameReply.EXISTS):
+        with pytest.raises(RuntimeError):
+            input_output._require_primary_owner(reply, input_output.APP_BUS)
+
+
+# ---------------------------------------------------------------------------
+# gsettings rollback: a failure mid-registration must restore the user's
+# original custom-keybindings list and reset the entries it wrote.
+# ---------------------------------------------------------------------------
+
+def test_keybinding_rollback_restores_list_on_failed_write(monkeypatch):
+    adapter = GnomeKeybindingShortcutAdapter(keyboard_repeat=(True, 500, 30))
+    adapter.bindings = [
+        ShortcutBinding("push_to_talk", "F9", ShortcutTrigger.HOLD),
+        ShortcutBinding("mode_switch", "Ctrl+Alt+M", ShortcutTrigger.ACTIVATE),
+    ]
+    adapter._binding_ids = {"push_to_talk", "mode_switch"}
+    user = _KB_BASE + "custom0/"
+    original = repr([user])
+    list_writes = []
+    reset_paths = []
+
+    def run(cmd, **kwargs):
+        if cmd[:2] == ["gsettings", "get"] and cmd[-1] == "custom-keybindings":
+            return _FakeProc(stdout=original)
+        if cmd[:2] == ["gsettings", "set"] and cmd[3] == "custom-keybindings":
+            written_list = ast.literal_eval(cmd[4])
+            list_writes.append(written_list)
+            # Fail the write that adds our entries; allow the rollback restore.
+            if any("witticism-" in p for p in written_list):
+                return _FakeProc(returncode=1, stderr="boom")
+            return _FakeProc()
+        if cmd[:2] == ["gsettings", "reset-recursively"]:
+            reset_paths.append(cmd[2])
+        return _FakeProc()
+
+    monkeypatch.setattr(input_output.subprocess, "run", run)
+    status = adapter._register()
+
+    assert status.state == AdapterState.FAILED
+    # Our just-written entries were reset, and the original user-only list restored.
+    assert any("witticism-push-to-talk" in p for p in reset_paths)
+    assert any("witticism-mode-switch" in p for p in reset_paths)
+    assert list_writes[-1] == [user]
+    # The user's own entry was never among the reset paths.
+    assert all("custom0" not in p for p in reset_paths)
+
+
+# ---------------------------------------------------------------------------
+# RemoteDesktop portal handshake (_open_session): the keyboard-granted bitmask,
+# restore-token persistence, and restore-token replay were previously untested.
+# ---------------------------------------------------------------------------
+
+def _remote_desktop_env(monkeypatch, adapter, started_result, select_options_capture):
+    import dbus_next.aio
+
+    monkeypatch.setattr(input_output, "portal_has_interface", lambda name: True)
+
+    class _Iface:
+        def call_create_session(self):
+            pass
+
+        def call_select_devices(self):
+            pass
+
+        def call_start(self):
+            pass
+
+    iface = _Iface()
+
+    class _Proxy:
+        def get_interface(self, name):
+            return iface
+
+    class _Bus:
+        def get_proxy_object(self, *args):
+            return _Proxy()
+
+        def disconnect(self):
+            pass
+
+    class _MB:
+        async def connect(self):
+            return _Bus()
+
+    monkeypatch.setattr(dbus_next.aio, "MessageBus", lambda: _MB())
+
+    async def fake_portal_request(bus, method, args, token):
+        if method == iface.call_create_session:
+            return {"session_handle": "/session/1"}
+        if method == iface.call_select_devices:
+            select_options_capture.append(args[1])
+            return {}
+        if method == iface.call_start:
+            return started_result
+        raise AssertionError("unexpected portal method")
+
+    monkeypatch.setattr(input_output, "_portal_request", fake_portal_request)
+
+    async def _noop_subscribe(self):
+        return None
+
+    monkeypatch.setattr(RemoteDesktopTypeAdapter, "_subscribe_session_closed", _noop_subscribe)
+    return iface
+
+
+def test_open_session_stores_token_when_keyboard_granted(monkeypatch, tmp_path):
+    pytest.importorskip("dbus_next")
+    adapter = RemoteDesktopTypeAdapter()
+    adapter.token_file = tmp_path / "state" / "wayland-portal.json"
+    captured = []
+    _remote_desktop_env(monkeypatch, adapter, {"devices": 1, "restore_token": "tok-123"}, captured)
+
+    asyncio.run(adapter._open_session())
+
+    assert adapter.ready is True
+    assert adapter.session == "/session/1"
+    assert adapter._load_token() == "tok-123"
+    assert "restore_token" not in captured[0]  # none existed to replay
+
+
+def test_open_session_raises_when_keyboard_not_granted(monkeypatch, tmp_path):
+    pytest.importorskip("dbus_next")
+    adapter = RemoteDesktopTypeAdapter()
+    adapter.token_file = tmp_path / "state" / "wayland-portal.json"
+    _remote_desktop_env(monkeypatch, adapter, {"devices": 0, "restore_token": "nope"}, [])
+
+    with pytest.raises(PermissionError):
+        asyncio.run(adapter._open_session())
+
+    assert adapter.ready is False
+    assert adapter._load_token() is None  # nothing persisted on denial
+
+
+def test_open_session_replays_existing_restore_token(monkeypatch, tmp_path):
+    pytest.importorskip("dbus_next")
+    adapter = RemoteDesktopTypeAdapter()
+    adapter.token_file = tmp_path / "state" / "wayland-portal.json"
+    adapter._store_token("prior-token")
+    captured = []
+    _remote_desktop_env(monkeypatch, adapter, {"devices": 1, "restore_token": "rotated"}, captured)
+
+    asyncio.run(adapter._open_session())
+
+    assert "restore_token" in captured[0]
+    assert captured[0]["restore_token"].value == "prior-token"
+    assert adapter._load_token() == "rotated"  # rotated token replaces the old one
+
+
+# ---------------------------------------------------------------------------
+# Concurrent transcripts must not interleave their keysyms.
+# ---------------------------------------------------------------------------
+
+def test_type_text_serializes_concurrent_calls():
+    pytest.importorskip("dbus_next")
+    adapter = RemoteDesktopTypeAdapter()
+    adapter.session = "/session/1"
+    order = []
+
+    class _Iface:
+        async def call_notify_keyboard_keysym(self, session, opts, keysym, state):
+            if state == 1:  # record presses only
+                order.append(chr(keysym))
+                await asyncio.sleep(0)  # yield: would interleave without the lock
+
+    adapter.interface = _Iface()
+
+    async def run():
+        await asyncio.gather(adapter._type_text("AB"), adapter._type_text("cd"))
+
+    asyncio.run(run())
+    assert "".join(order) in ("ABcd", "cdAB")  # never interleaved
+
+
+def test_store_token_tightens_loose_state_dir(tmp_path):
+    adapter = RemoteDesktopTypeAdapter()
+    state = tmp_path / "state"
+    state.mkdir()
+    os.chmod(state, 0o777)  # simulate a pre-existing world-accessible dir
+    adapter.token_file = state / "wayland-portal.json"
+
+    adapter._store_token("secret")
+
+    assert stat.S_IMODE(state.stat().st_mode) == 0o700

--- a/tests/test_platform_adapters.py
+++ b/tests/test_platform_adapters.py
@@ -1441,3 +1441,64 @@ def test_ptt_transition_callbacks_fire_once_under_lock():
     assert manager._end_ptt() is True
     assert manager._end_ptt() is False     # already stopped: no duplicate stop
     assert events == ["start", "stop"]
+
+
+def test_set_mode_does_not_arm_swallow_after_release_debounce():
+    """If the PTT key was already released (a debounce stop is pending) when the
+    user switches to toggle, no trailing release is coming, so the swallow must
+    NOT be armed - otherwise the first real toggle press would be eaten."""
+    adapter = FakeShortcutAdapter()  # supports_hold True
+    manager = HotkeyManager(DebounceConfig(1000), adapter=adapter)
+    flips = []
+    manager.set_callbacks(on_toggle_dictation=lambda active: flips.append(active))
+    manager.start()
+    adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)    # hold begins
+    adapter.emit("push_to_talk", ShortcutEventType.DEACTIVATED)  # release -> debounce stop scheduled
+    assert manager.ptt_active is True                            # still within debounce window
+    manager.set_mode("toggle")                                  # release already seen
+    assert manager._pending_ptt_release is False
+    adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)
+    adapter.emit("push_to_talk", ShortcutEventType.DEACTIVATED)
+    assert flips == [True]                                       # first toggle NOT swallowed
+
+
+def test_switch_out_and_back_does_not_strand_swallow():
+    """Switching PTT->toggle mid-hold then back to PTT must clear the swallow, so
+    a later genuine release is never eaten (which would leave the mic stuck)."""
+    adapter = FakeShortcutAdapter()  # supports_hold True
+    manager = HotkeyManager(FakeConfig(), adapter=adapter)  # debounce 1ms
+    events = []
+    manager.set_callbacks(
+        on_push_to_talk_start=lambda: events.append("start"),
+        on_push_to_talk_stop=lambda: events.append("stop"),
+    )
+    manager.start()
+    adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)   # hold begins (key still down)
+    manager.set_mode("toggle")
+    assert manager._pending_ptt_release is True                 # armed (key was held)
+    manager.set_mode("push_to_talk")
+    assert manager._pending_ptt_release is False                # cleared on switch back
+    events.clear()
+    adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)
+    adapter.emit("push_to_talk", ShortcutEventType.DEACTIVATED)
+    time.sleep(0.02)                                            # let the 1ms debounce stop fire
+    assert manager.ptt_active is False                          # not stuck recording
+    assert events == ["start", "stop"]
+
+
+def test_set_mode_cancels_not_stops_when_cancel_wired():
+    """With a cancel handler wired, leaving PTT mid-capture fires cancel
+    (discard), never stop (which would transcribe the partial)."""
+    adapter = FakeNoHoldAdapter()
+    manager = HotkeyManager(FakeConfig(), adapter=adapter)
+    events = []
+    manager.set_callbacks(
+        on_push_to_talk_start=lambda: events.append("start"),
+        on_push_to_talk_stop=lambda: events.append("stop"),
+        on_push_to_talk_cancel=lambda: events.append("cancel"),
+    )
+    manager.start()
+    adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)  # recording
+    manager.set_mode("toggle")
+    assert events == ["start", "cancel"]
+    assert manager.ptt_active is False

--- a/tests/test_platform_adapters.py
+++ b/tests/test_platform_adapters.py
@@ -1469,24 +1469,30 @@ def test_set_mode_after_release_debounce_commits_not_discards():
     assert flips == [True]                                       # first toggle NOT swallowed
 
 
-def test_pending_release_not_stranded_by_mode_switch_race():
-    """Simulate the mode-switch race: the armed release is delivered while mode
-    is still push_to_talk. It must be consumed there rather than left armed to
-    swallow the user's first genuine toggle-dictation press."""
+def test_mode_switch_is_atomic_under_state_lock():
+    """set_mode holds _state_lock across the whole transition, so a shortcut
+    event delivered concurrently cannot interleave with the commit/cancel +
+    swallow-arm + mode-flip (the whole class of mode-switch races)."""
     adapter = FakeShortcutAdapter()  # supports_hold True
     manager = HotkeyManager(FakeConfig(), adapter=adapter)
-    flips = []
-    manager.set_callbacks(on_toggle_dictation=lambda active: flips.append(active))
     manager.start()
-    # Intermediate race state: swallow armed, mode not yet flipped.
-    manager._pending_ptt_release = True
-    assert manager.mode == "push_to_talk"
-    adapter.emit("push_to_talk", ShortcutEventType.DEACTIVATED)  # lands in the ptt branch
-    assert manager._pending_ptt_release is False                # consumed, not stranded
-    manager.set_mode("toggle")
-    adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)
-    adapter.emit("push_to_talk", ShortcutEventType.DEACTIVATED)
-    assert flips == [True]                                       # first toggle works
+    adapter.emit("push_to_talk", ShortcutEventType.ACTIVATED)  # hold begins (key held)
+
+    # A shortcut event arriving mid-set_mode must block on the same lock. Prove
+    # mutual exclusion: while _state_lock is held, the handler cannot run.
+    import threading
+    ran = threading.Event()
+
+    def deliver_release():
+        adapter.emit("push_to_talk", ShortcutEventType.DEACTIVATED)
+        ran.set()
+
+    with manager._state_lock:
+        t = threading.Thread(target=deliver_release, daemon=True)
+        t.start()
+        assert not ran.wait(0.1)  # blocked on the lock, cannot interleave
+    t.join(timeout=1)
+    assert ran.is_set()  # proceeds once the lock is released
 
 
 def test_switch_out_and_back_does_not_strand_swallow():

--- a/tests/test_system_tray.py
+++ b/tests/test_system_tray.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""System-tray tests: the mode-switch blocker fix and the hotkey-callback
+marshaling wiring.
+
+Runs headless in CI (QT_QPA_PLATFORM=offscreen, PyQt5 installed). Skips cleanly
+where PyQt5 or numpy (pulled in by the tray's transcriber import) is absent.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+pytest.importorskip("PyQt5")
+pytest.importorskip("numpy")
+
+import numpy as np
+from PyQt5.QtWidgets import QApplication
+
+from witticism.ui.system_tray import SystemTrayApp
+
+
+@pytest.fixture(scope="module")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+class _AudioStub:
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+
+    def start_push_to_talk(self):
+        self.started = True
+
+    def stop_push_to_talk(self):
+        self.stopped = True
+        return np.array([], dtype="float32")  # empty -> no transcription kicked off
+
+
+def test_change_mode_toggle_stops_active_recording(app):
+    """Switching to Toggle while a push-to-talk capture is live must stop the
+    mic (regression for the stuck-recording blocker)."""
+    tray = SystemTrayApp()
+    tray.is_enabled = True
+    audio = _AudioStub()
+    tray.audio_capture = audio
+    tray.hotkey_manager = None
+
+    tray.start_recording()
+    assert tray.is_recording is True
+
+    tray.change_mode("toggle")
+
+    assert tray.is_recording is False
+    assert audio.stopped is True
+
+
+def test_change_mode_toggle_noop_when_not_recording(app):
+    tray = SystemTrayApp()
+    tray.is_enabled = True
+    audio = _AudioStub()
+    tray.audio_capture = audio
+    tray.hotkey_manager = None
+
+    tray.change_mode("toggle")  # nothing in flight
+
+    assert tray.is_recording is False
+    assert audio.stopped is False
+
+
+def test_request_wrappers_emit_signals(app):
+    """The thread-safe entry points the hotkey manager calls just emit signals."""
+    tray = SystemTrayApp()
+    fired = []
+    tray.ptt_start_requested.connect(lambda: fired.append("start"))
+    tray.ptt_stop_requested.connect(lambda: fired.append("stop"))
+    tray.toggle_enabled_requested.connect(lambda: fired.append("enabled"))
+    tray.toggle_dictation_requested.connect(lambda active: fired.append(("dictation", active)))
+
+    tray.request_ptt_start()
+    tray.request_ptt_stop()
+    tray.request_toggle_enabled()
+    tray.request_toggle_dictation(True)
+    app.processEvents()
+
+    assert fired == ["start", "stop", "enabled", ("dictation", True)]
+
+
+def test_set_components_wires_hotkey_signals_to_handlers(app):
+    """set_components connects the marshaling signals to the real handlers, so a
+    hotkey event delivered off-thread drives start/stop on the GUI thread."""
+    tray = SystemTrayApp()
+    tray.is_enabled = True
+    audio = _AudioStub()
+    try:
+        tray.set_components(None, audio, None, None, None)
+    except Exception:
+        # The connect block runs before any component-dependent menu refresh, so
+        # the signal wiring is in place even if the tail needs real components.
+        pass
+
+    tray.request_ptt_start()
+    app.processEvents()
+    assert tray.is_recording is True
+    assert audio.started is True
+
+    tray.request_ptt_stop()
+    app.processEvents()
+    assert tray.is_recording is False
+    assert audio.stopped is True
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_system_tray.py
+++ b/tests/test_system_tray.py
@@ -115,5 +115,38 @@ def test_set_components_wires_hotkey_signals_to_handlers(app):
     assert audio.stopped is True
 
 
+def test_change_mode_tolerates_non_string_ptt_key(app):
+    """A non-string hotkeys.push_to_talk (hand-edited/corrupt config) must not
+    crash the mode switch on .upper()."""
+    class _Cfg:
+        def get(self, key, default=None):
+            if key == "hotkeys.push_to_talk":
+                return None
+            return default
+
+    tray = SystemTrayApp()
+    tray.config_manager = _Cfg()
+    tray.hotkey_manager = None
+    tray.change_mode("toggle")        # must not raise AttributeError
+    tray.change_mode("push_to_talk")
+    assert tray._ptt_key_label() == "F9"
+
+
+def test_abort_recording_discards_without_transcribing(app):
+    """abort_recording stops the mic and drops the buffer; it never transcribes."""
+    tray = SystemTrayApp()
+    tray.is_enabled = True
+    audio = _AudioStub()
+    tray.audio_capture = audio
+    transcribed = []
+    tray.process_transcription = lambda data: transcribed.append(data)
+    tray.start_recording()
+    assert tray.is_recording is True
+    tray.abort_recording()
+    assert tray.is_recording is False
+    assert audio.stopped is True
+    assert transcribed == []  # partial capture discarded, not injected
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Post-merge follow-ups to the review of #125 (Wayland platform adapters, #124). Fixes one user-facing blocker plus D-Bus trust-model, thread-safety, and config-robustness gaps found in review, and closes the two largest test holes. Adds PyQt5 (headless) to CI so the system-tray logic is testable.

All findings were reproduced against the merged code before fixing.

## Blocker

- **Mode switch mid-recording no longer sticks the mic on.** `HotkeyManager.set_mode` / `SystemTrayApp.change_mode` now stop an in-flight push-to-talk capture when leaving `push_to_talk` mode. Previously `ptt_active` stayed set, the mic recorded until shutdown, and tray health pinned at `RECORDING`, because the in-flight press never received its matching release (later `ACTIVATED` events route to dictation).

## D-Bus trust model

- **`TriggerShortcut` is authenticated.** `GnomeKeybindingShortcutAdapter` (the no-install GNOME 46/47 default) embeds a per-process secret in the registered gsettings command and requires it on every call, so a co-resident process can no longer key the microphone by calling the well-known method. Same-UID processes remain within the session-bus trust boundary; this closes opportunistic/cross-app triggering.
- **Name-squatting is refused.** Both GNOME adapters now require `request_name` to return `PRIMARY_OWNER` (`DO_NOT_QUEUE`) and refuse to run behind a squatter that the extension's own sender check would otherwise trust.

## Thread-safety

- **Hotkey callbacks are marshaled to the GUI thread** via `pyqtSignal`s instead of mutating Qt widgets directly from the D-Bus runtime / debounce Timer thread.
- **`ptt_active` transitions are lock-guarded**, closing the Timer/D-Bus TOCTOU race.
- **Wayland typing is serialized** with an `asyncio` lock so two transcripts dictated in quick succession cannot interleave their keysyms.

## Config robustness

- The `toggle_enable` → `mode_switch` migration **drops a null/number/empty legacy value** (falling back to the default) instead of persisting one that crashes accelerator parsing; `HotkeyManager` also coerces bad values defensively.
- `save_config` writes via a **temp file + atomic replace**, so an interrupted write can no longer truncate `config.json` and reset every setting to defaults.
- The portal state directory is tightened to `0700` even if it pre-existed.

## Tests (110 → 131)

- Cover the RemoteDesktop `_open_session` handshake (keyboard bitmask, restore-token persistence and replay) and the gsettings `_rollback`-on-failure path — both previously fully mocked out.
- Add `set_mode` both-direction, `TriggerShortcut` auth, name-ownership, typing-serialization, config-hardening, and tray `change_mode` / marshaling tests.
- CI test job installs `PyQt5` + `numpy` and runs headless (`QT_QPA_PLATFORM=offscreen`) with `PYTHONPATH=src`, so the tray tests run and imports no longer depend on a test-file `sys.path` side effect.

Also removes the dead `HotkeyManager.change_ptt_key`.
